### PR TITLE
Add: VPC Endpoints

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -47,26 +47,3 @@ resource "aws_lb_target_group" "alb_tg" {
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id # VPCを指定
 }
-
-# ALBに適用するセキュリティグループ
-resource "aws_security_group" "alb_sg" {
-  name        = "allow_http_https"
-  description = "Allow HTTP and HTTPS inbound traffic"
-  vpc_id      = aws_vpc.main.id
-
-  # HTTPに対するインバウンドルール
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 任意のIPからのアクセスを許可
-  }
-
-  # HTTPSに対するインバウンドルール
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 任意のIPからのアクセスを許可
-  }
-}

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -3,29 +3,6 @@ resource "aws_ecs_cluster" "tunetrail" {
   name = "tunetrail"
 }
 
-# ECSタスク用のセキュリティグループ
-resource "aws_security_group" "sg" {
-  name        = "ecs_tasks_sg"
-  description = "Security Group for ECS Tasks"
-  vpc_id      = aws_vpc.main.id
-
-  # DBへのアクセス用のインバウンドルールの設定
-  ingress {
-    from_port   = 5432 # DBのポート番号
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
-  }
-
-  # アウトバウンドルールの設定
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] # 任意のIPへのアクセスを許可
-  }
-}
-
 # tunetrail-api サービスの設定
 resource "aws_ecs_service" "api" {
   name            = "tunetrail-api"

--- a/infra/security_group.tf
+++ b/infra/security_group.tf
@@ -1,0 +1,45 @@
+# ALB用のセキュリティグループ
+resource "aws_security_group" "alb_sg" {
+  name        = "allow_http_https"
+  description = "Allow HTTP and HTTPS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  # HTTPに対するインバウンドルール
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # 任意のIPからのアクセスを許可
+  }
+
+  # HTTPSに対するインバウンドルール
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # 任意のIPからのアクセスを許可
+  }
+}
+
+# ECSタスク用のセキュリティグループ
+resource "aws_security_group" "sg" {
+  name        = "ecs_tasks_sg"
+  description = "Security Group for ECS Tasks"
+  vpc_id      = aws_vpc.main.id
+
+  # DBへのアクセス用のインバウンドルールの設定
+  ingress {
+    from_port   = 5432 # DBのポート番号
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
+  }
+
+  # アウトバウンドルールの設定
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # 任意のIPへのアクセスを許可
+  }
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,5 +1,7 @@
 resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true # プライベートDNS
+  enable_dns_hostnames = true # ホスト名の自動設定
 }
 
 # パブリックサブネット

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -1,0 +1,20 @@
+# ECRのAPIを呼び出すためのVPCエンドポイント
+# イメージのメタデータを取得したり、イメージの認証トークンを取得するために使用される。
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
+  security_group_ids  = [aws_security_group.sg.id]
+  private_dns_enabled = true
+}
+
+# Dockerイメージのプッシュ/プルを行うためのVPCエンドポイント
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
+  security_group_ids  = [aws_security_group.sg.id]
+  private_dns_enabled = true
+}


### PR DESCRIPTION
## 概要

VPCエンドポイントを追加しました。

## 関連Issue

関連するIssueはありません

## 変更点

- [ ] VPC内の各インスタンスに対してパブリックDNSホスト名が付与されるようにVPCの設定を変更
- [ ] ECRのAPIを呼び出すためのVPCエンドポイント`ecr_api`を追加
- [ ] Dockerイメージのプッシュ/プルを行うためのVPCエンドポイント`ecr_dkr`を追加
- [ ] セキュリティグループのコードを`security_group.tf`に切り出し

## 動作確認

- `terraform validate` 、`terraform plan`を実行し、不整合がないことを確認
- `terraform apply`を実行し、変更が正しく適用されることを確認
