### PR TITLE
Add: environment variables to ecs task definitions

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,8 @@ COPY ./ ./
 
 RUN npm install
 
+RUN npm run build
+
 CMD [ "npm", "start" ]
 
 # ---------------------------------------------------

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -24,6 +24,28 @@ resource "aws_ecs_task_definition" "api" {
     portMappings = [{
       containerPort = 8080
     }],
+    environment = [
+      {
+        name  = "TUNETRAIL_DB_HOST"
+        value = "${aws_db_instance.tunetrail.address}"
+      },
+      {
+        name  = "TUNETRAIL_DB_PORT"
+        value = tostring(aws_db_instance.tunetrail.port)
+      },
+      {
+        name  = "TUNETRAIL_DB_USER"
+        value = "${aws_db_instance.tunetrail.username}"
+      },
+      {
+        name  = "TUNETRAIL_DB_PASSWORD"
+        value = "${aws_db_instance.tunetrail.password}"
+      },
+      {
+        name  = "TUNETRAIL_DB_NAME"
+        value = "${aws_db_instance.tunetrail.name}"
+      },
+    ],
     logConfiguration = {
       logDriver = "awslogs", # CloudWatch Logsを使用する
       options = {
@@ -64,6 +86,12 @@ resource "aws_ecs_task_definition" "frontend" {
     portMappings = [{
       containerPort = 3000
     }],
+    environment = [
+      {
+        name  = "NEXT_PUBLIC_API_ROOT"
+        value = "https://${var.api_domain}"
+      },
+    ],
     logConfiguration = {
       logDriver = "awslogs", # CloudWatch Logsを使用する
       options = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,3 +1,9 @@
+variable "api_domain" {
+  description = "The domain name for the API"
+  type        = string
+  default     = "api.tune-trail.com"
+}
+
 variable "db_password" {
   description = "The password for the DB instance"
   type        = string


### PR DESCRIPTION
## 概要

ECSタスク定義に環境変数を追加しました。その他軽微な修正をしました。

## 関連Issue

関連するIssueはありません

## 変更点

- [ ] frontendのECSタスク定義に`.env.local`で設定する環境変数を追加
- [ ] apiのECSタスク定義に`docker-compose.yml`で設定する環境変数を追加
- [ ] frontendのdeploy用の`Dockerfile`に`npm run build`を書き忘れていたので追加
