### PR TITLE
Fix: Change triggered branch from master to main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -3,7 +3,7 @@ name: Deploy api to ECS
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy-api:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -3,7 +3,7 @@ name: Deploy frontend to ECS
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy-frontend:


### PR DESCRIPTION
## 概要

トリガーされるブランチの名前を`master`から`main`に変更しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] トリガーされるブランチの名前を`master`から`main`に変更しました。

## 追加タスク

- [ ] ECRにイメージがプッシュされているか確認
- [ ] ECSにデプロイされているか確認
- [ ] CloudWatch Logsでログが出力されているか確認
- [ ] ブラウザからアクセスできることを確認

## 影響範囲

正常に動作した場合、ECRにイメージがプッシュされ、ECSにデプロイされます。

