### PR TITLE
GitHub Actionsがデプロイ時に一時的にロールを引き受けるように変更

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -24,6 +24,15 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ap-northeast-1
 
+    # ロールを引き継ぐ
+    - name: Assume IAM Role
+      run: |
+        aws sts assume-role --role-arn ${{ secrets.AWS_ROLE_TO_ASSUME }} --role-session-name GitHubActions --output json > assume-role-output.json
+
+        echo "AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId assume-role-output.json)" >> $GITHUB_ENV
+        echo "AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey assume-role-output.json)" >> $GITHUB_ENV
+        echo "AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken assume-role-output.json)" >> $GITHUB_ENV
+
     - name: Login to Amazon ECR
       id: login-ecr-api
       uses: aws-actions/amazon-ecr-login@v1

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,3 +1,65 @@
+# GitHub Actions 用の IAM ロール
+resource "aws_iam_role" "github_actions" {
+  name = "github_actions_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+# GitHub Actions 用の IAM ポリシー
+# ECRからイメージをプル、プッシュ、
+# ECSにデプロイなどに必要な権限を持つポリシー
+resource "aws_iam_role_policy" "github_actions_policy" {
+  name = "github_actions_policy"
+  role = aws_iam_role.github_actions.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:DescribeImages",
+        "ecr:BatchGetImage",
+        "ecr:GetLifecyclePolicy",
+        "ecr:GetLifecyclePolicyPreview",
+        "ecr:ListTagsForResource",
+        "ecr:DescribeImageScanFindings",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecs:RegisterTaskDefinition",
+        "ecs:UpdateService",
+        "ecs:DescribeServices"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
 # ECS タスク実行ロール
 ## タスクの実行に必要な基本的な権限を持つロール
 resource "aws_iam_role" "execution_role" {


### PR DESCRIPTION
## 概要

GitHub Actionsがデプロイ時に一時的にロールを引き受けるように変更しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] GitHub Actionsが引き継ぐロールを作成
- [ ] 上記のロールのポリシーを作成
- [ ] ワークフローファイルにロールを引き継ぐコードを追加
