### PR TITLE
ECSサービスでFargateを明示的に指定

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -9,6 +9,7 @@ resource "aws_ecs_service" "api" {
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.api.arn
   desired_count   = 2 # タスクの数
+  launch_type     = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
     security_groups  = [aws_security_group.sg.id]
@@ -71,6 +72,7 @@ resource "aws_ecs_service" "frontend" {
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.frontend.arn
   desired_count   = 2
+  launch_type     = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
     security_groups  = [aws_security_group.sg.id]


### PR DESCRIPTION
## 概要

ECSサービスの`launch_type`を明示的に指定していなかったので、`EC2`になっていました。
`Fargate`を指定するように変更しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] ECSサービスの`launch_type`を`Fargate`に変更

