### PR TITLE
VPCエンドポイント用のインバウンドルールを追加

### DIFF
--- a/infra/security_group.tf
+++ b/infra/security_group.tf
@@ -35,6 +35,14 @@ resource "aws_security_group" "sg" {
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
   }
 
+  # VPCエンドポイント用のインバウンドルールの設定
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
+  }
+
   # アウトバウンドルールの設定
   egress {
     from_port   = 0


### PR DESCRIPTION
## 概要

VPCエンドポイント用のインバウンドルールが存在しなかったため、ECSがECRからイメージをプルできていない可能性があります。VPCエンドポイント用のインバウンドルールを追加しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] VPCエンドポイント用のインバウンドルールをセキュリティグループに追加

## 追加タスク

ECSがECRからイメージをプルして、タスクが起動することを確認してください。

## 動作確認

`terraform validate`、`terraform plan`でエラーが発生しないことを確認しました。
