### PR TITLE
ECSタスク実行ロールにS3とECRのreadonly権限を追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,6 @@
 .PHONY: help build build-local up down logs ps test
 .DEFAULT_GOAL := help
 
-# test
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
 	docker build -t kwtryo/tunetrail/api:${DOCKER_TAG} \

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -52,6 +52,18 @@ resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+# S3 ReadOnlyアクセスポリシーをexecution_roleにアタッチ
+resource "aws_iam_role_policy_attachment" "s3_read_only" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+# ECR ReadOnlyアクセスポリシーをexecution_roleにアタッチ
+resource "aws_iam_role_policy_attachment" "ecr_read_only" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
 # ECS タスク実行ロールに CloudWatch Logs への書き込み権限を付与
 resource "aws_iam_policy" "cloudwatch_logs_policy" {
   name        = "CloudWatchLogsPolicy"

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -58,12 +58,6 @@ resource "aws_iam_role_policy_attachment" "s3_read_only" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
 
-# ECR ReadOnlyアクセスポリシーをexecution_roleにアタッチ
-resource "aws_iam_role_policy_attachment" "ecr_read_only" {
-  role       = aws_iam_role.execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-}
-
 # ECS タスク実行ロールに CloudWatch Logs への書き込み権限を付与
 resource "aws_iam_policy" "cloudwatch_logs_policy" {
   name        = "CloudWatchLogsPolicy"


### PR DESCRIPTION
## 概要

ECSタスクがS3のアクセスに失敗しているので、権限を追加しました。
Amazon ECRは、Dockerイメージの実際のレイヤーをAmazon S3に保存しています。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] S3のReadOnly権限を追加
- [ ] GHAをトリガーさせるためにコメントを追加

