### PR TITLE
S3用のVPCエンドポイントを追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help build build-local up down logs ps test
 .DEFAULT_GOAL := help
 
+# test
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
 	docker build -t kwtryo/tunetrail/api:${DOCKER_TAG} \

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -18,3 +18,12 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   security_group_ids  = [aws_security_group.sg.id]
   private_dns_enabled = true
 }
+
+# S3用のVPCエンドポイント
+# ECRのイメージをプッシュ/プルする際に、S3のバケットを使用するために必要。
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.public.id]
+}


### PR DESCRIPTION
## 概要

ECRからプルする時にS3にアクセスしますが、S3に接続するエンドポイントがありませんでした。
エンドポイントを追加しました。

## 関連Issue

関連するIssueはありません

## 変更点

- [ ] S3に接続するエンドポイントを追加
- [ ] GHAがトリガーされるようにコメントを追加

