### PR TITLE
プライベートサブネットにルートテーブルを追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,6 @@
 .PHONY: help build build-local up down logs ps test
 .DEFAULT_GOAL := help
 
-# test
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
 	docker build -t kwtryo/tunetrail/api:${DOCKER_TAG} \

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -58,3 +58,17 @@ resource "aws_subnet" "private2" {
   cidr_block        = "10.0.4.0/24"
   availability_zone = "ap-northeast-1c"
 }
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route_table_association" "private1" {
+  subnet_id      = aws_subnet.private1.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private2" {
+  subnet_id      = aws_subnet.private2.id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -25,5 +25,5 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id            = aws_vpc.main.id
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids   = [aws_route_table.public.id]
+  route_table_ids   = [aws_route_table.private.id]
 }


### PR DESCRIPTION
## 概要

プライベートサブネットにルートテーブルが作成されていなかったので、S3のVPCエンドポイントが通信できていませんでした。プライベートサブネットにルートテーブルを追加しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] プライベートサブネットにルートテーブルを追加
- [ ] S3のVPCエンドポイントに上記で作成したルートテーブルを指定
- [ ] GHAがトリガーされるようにコメントを追加
