### PR TITLE
CloudWatch Logs用のVPCエンドポイントを追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help build build-local up down logs ps test
 .DEFAULT_GOAL := help
 
+# test
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
 	docker build -t kwtryo/tunetrail/api:${DOCKER_TAG} \

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -27,3 +27,14 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_endpoint_type = "Gateway"
   route_table_ids   = [aws_route_table.private.id]
 }
+
+# CloudWatch Logs用のVPCエンドポイント
+resource "aws_vpc_endpoint" "cloudwatch_logs" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.ap-northeast-1.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
+  security_group_ids  = [aws_security_group.sg.id]
+  private_dns_enabled = true
+}
+


### PR DESCRIPTION
## 概要

このPRについての簡単な説明を記述してください。

## 関連Issue

CloudWatch Logs用のVPCエンドポイントが存在しなかったので追加しました。

## 変更点

- [ ] CloudWatch Logs用のVPCエンドポイントを追加
- [ ] GHAがトリガーされるようにコメントを追加

