### PR TITLE
コメントを追加

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,7 +1,6 @@
 .PHONY: help build build-local up down logs ps test
 .DEFAULT_GOAL := help
 
-# test
 DOCKER_TAG := latest
 build: ## Build docker image to deploy
 	docker build -t kwtryo/tunetrail/api:${DOCKER_TAG} \

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -9,7 +9,8 @@ resource "aws_ecs_service" "api" {
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.api.arn
   desired_count   = 2 # タスクの数
-  launch_type     = "FARGATE"
+  # desired_count = 0 # 一時的に無効化する場合は0にする
+  launch_type = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
     security_groups  = [aws_security_group.sg.id]
@@ -72,7 +73,8 @@ resource "aws_ecs_service" "frontend" {
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.frontend.arn
   desired_count   = 2
-  launch_type     = "FARGATE"
+  # desired_count = 0 # 一時的に無効化する場合は0にする
+  launch_type = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
     security_groups  = [aws_security_group.sg.id]

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -1,6 +1,7 @@
 # ECRのAPIを呼び出すためのVPCエンドポイント
 # イメージのメタデータを取得したり、イメージの認証トークンを取得するために使用される。
 resource "aws_vpc_endpoint" "ecr_api" {
+  # count               = 0 # 一時的に無効化する場合は0にする
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
   vpc_endpoint_type   = "Interface"
@@ -11,6 +12,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
 
 # Dockerイメージのプッシュ/プルを行うためのVPCエンドポイント
 resource "aws_vpc_endpoint" "ecr_dkr" {
+  # count               = 0 # 一時的に無効化する場合は0にする
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = "Interface"
@@ -22,6 +24,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
 # S3用のVPCエンドポイント
 # ECRのイメージをプッシュ/プルする際に、S3のバケットを使用するために必要。
 resource "aws_vpc_endpoint" "s3" {
+  # count             = 0 # 一時的に無効化する場合は0にする
   vpc_id            = aws_vpc.main.id
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = "Gateway"
@@ -30,6 +33,7 @@ resource "aws_vpc_endpoint" "s3" {
 
 # CloudWatch Logs用のVPCエンドポイント
 resource "aws_vpc_endpoint" "cloudwatch_logs" {
+  count               = 0 # 一時的に無効化する場合は0にする
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.logs"
   vpc_endpoint_type   = "Interface"


### PR DESCRIPTION
## 概要

AWSの課金額が増えるのを防ぐため、使用しないリソースをすぐに止められるようにコメントを追加しました。必要に応じてコメントアウトを解除してください。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] ECSタスクの`desired_count`を0にするコードのコメントを追加
- [ ] VPCエンドポイントの`count`を0にするコードのコメントを追加
