### PR TITLE
ルーターのセットアップ付近のエラー調査

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -18,7 +18,10 @@ func main() {
 	}
 
 	// バリデーションの初期化
-	validate.InitValidation()
+	if err := validate.InitValidation(); err != nil {
+		log.Printf("cannot init validation: %v", err)
+		os.Exit(1)
+	}
 
 	// ルーターの初期化
 	r, cleanup, err := router.SetupRouter(cfg)

--- a/api/main.go
+++ b/api/main.go
@@ -12,17 +12,21 @@ import (
 )
 
 func main() {
+	log.Print("start main")
 	cfg, err := config.New()
 	if err != nil {
-		log.Fatal("cannot get config")
+		log.Printf("cannot get config: %v", err)
+		os.Exit(1)
 	}
 
+	log.Print("init validation")
 	// バリデーションの初期化
 	if err := validate.InitValidation(); err != nil {
 		log.Printf("cannot init validation: %v", err)
 		os.Exit(1)
 	}
 
+	log.Print("setup router")
 	// ルーターの初期化
 	r, cleanup, err := router.SetupRouter(cfg)
 	if err != nil {
@@ -31,9 +35,11 @@ func main() {
 	}
 	defer cleanup()
 
+	log.Print("run server")
 	// サーバーの起動
 	if err := runner.Run(context.Background(), r, cfg); err != nil {
 		log.Printf("failed to terminated server: %v", err)
 		os.Exit(1)
 	}
+	log.Print("end main")
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"log"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -13,8 +14,11 @@ import (
 )
 
 func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
+	log.Print("router: start router.setupRouter")
+	log.Print("router: setup gin router")
 	router := gin.Default()
 
+	log.Print("router: setup db")
 	db, cleanup, err := store.New(cfg)
 	if err != nil {
 		return nil, cleanup, err
@@ -30,8 +34,10 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 		Service: &service.UserService{DB: db, Repo: r},
 	}
 
+	log.Print("router: setup cors middleware")
 	router.Use(CorsMiddleware())
 
+	log.Print("router: setup endpoints")
 	router.GET("/health", hh.HealthCheck)
 	user := router.Group("/user")
 	{
@@ -41,6 +47,7 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 		user.DELETE("/:user_name", uh.DeleteUserByUserName)
 	}
 
+	log.Print("router: end router.setupRouter")
 	return router, cleanup, nil
 }
 

--- a/api/validate/validator.go
+++ b/api/validate/validator.go
@@ -9,14 +9,14 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-func InitValidation() {
+func InitValidation() error {
 	// カスタムバリデーションルールを登録
 	validate := binding.Validator.Engine().(*validator.Validate)
 	err := validate.RegisterValidation("password", passwordValidation)
 	if err != nil {
-		fmt.Printf("Failed to register custom validation: %v\n", err)
-		return
+		return fmt.Errorf("failed to register custom validation: %w", err)
 	}
+	return nil
 }
 
 // passwordValidationはパスワードのバリデーションを行う関数


### PR DESCRIPTION
## 概要

ECSで動かすとルーターのセットアップ付近でエラーが起きているようなので、詳細なログを追加しました。また、バリデーションのセットアップ関数でエラーが起きている可能性もあるので、正しくエラーハンドリングされるように改修しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] main関数にトレースログを追加しました
- [ ] router.SetupRouterにトレースログを追加しました
- [ ] validate.InitValidationが呼び出し元にエラーを渡すように改修しました

