### PR TITLE
DB初期化関数にトレースログを追加

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -12,21 +12,18 @@ import (
 )
 
 func main() {
-	log.Print("start main")
 	cfg, err := config.New()
 	if err != nil {
 		log.Printf("cannot get config: %v", err)
 		os.Exit(1)
 	}
 
-	log.Print("init validation")
 	// バリデーションの初期化
 	if err := validate.InitValidation(); err != nil {
 		log.Printf("cannot init validation: %v", err)
 		os.Exit(1)
 	}
 
-	log.Print("setup router")
 	// ルーターの初期化
 	r, cleanup, err := router.SetupRouter(cfg)
 	if err != nil {
@@ -35,11 +32,9 @@ func main() {
 	}
 	defer cleanup()
 
-	log.Print("run server")
 	// サーバーの起動
 	if err := runner.Run(context.Background(), r, cfg); err != nil {
 		log.Printf("failed to terminated server: %v", err)
 		os.Exit(1)
 	}
-	log.Print("end main")
 }

--- a/api/store/repository.go
+++ b/api/store/repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/kwtryo/tunetrail/api/clock"
@@ -42,6 +43,9 @@ type Repository struct {
 
 // NewはconfigからDBオブジェクトを返す
 func New(cfg *config.Config) (*sqlx.DB, func(), error) {
+	log.Print("store: start store.New")
+	log.Print("store: open db")
+	log.Printf("store: db host: %s db port: %v db user: %s db name: %s", cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBName)
 	driver := "postgres"
 	db, err := sql.Open(driver, fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
@@ -49,14 +53,18 @@ func New(cfg *config.Config) (*sqlx.DB, func(), error) {
 		cfg.DBPassword, cfg.DBName,
 	))
 	if err != nil {
+		log.Printf("store: failed to open db: %v", err)
 		return nil, nil, err
 	}
 
+	log.Print("store: ping db")
 	// sql.Openは接続確認が行われないため、ここで確認する。
 	if err := db.Ping(); err != nil {
+		log.Printf("store: failed to ping db: %v", err)
 		return nil, func() { _ = db.Close() }, err
 	}
 	xdb := sqlx.NewDb(db, driver)
+	log.Print("store: end store.New")
 	return xdb, func() { _ = db.Close() }, nil
 }
 


### PR DESCRIPTION
## 概要

DBの接続周りでエラーが起きているようなので、DB初期化関数にログを追加しました。

## 関連Issue

関連するIssueはありません

## 変更点

- [ ] mainのトレースログを削除
- [ ] store.Newにトレースログを追加
