### PR TITLE
DBとAPIが疎通できない問題の修正

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -28,6 +28,14 @@ resource "aws_ecs_task_definition" "api" {
     }],
     environment = [
       {
+        name  = "TUNETRAIL_ENV"
+        value = "prod"
+      },
+      {
+        name  = "PORT"
+        value = "80"
+      },
+      {
         name  = "TUNETRAIL_DB_HOST"
         value = "${aws_db_instance.tunetrail.address}"
       },

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -11,16 +11,17 @@ resource "aws_db_subnet_group" "tunetrail" {
 
 # RDSインスタンス
 resource "aws_db_instance" "tunetrail" {
-  allocated_storage    = 10
-  storage_type         = "gp2" # 汎用SSD
-  engine               = "postgres"
-  engine_version       = "15.2"
-  instance_class       = "db.t3.micro"
-  name                 = "tunetrail"
-  username             = "tunetrail"
-  password             = var.db_password
-  parameter_group_name = "default.postgres15"
-  db_subnet_group_name = aws_db_subnet_group.tunetrail.name
-  publicly_accessible  = false # インターネットからの直接のアクセスを拒否
-  skip_final_snapshot  = true  # 削除時にスナップショットを作成しない
+  allocated_storage      = 10
+  storage_type           = "gp2" # 汎用SSD
+  engine                 = "postgres"
+  engine_version         = "15.2"
+  instance_class         = "db.t3.micro"
+  name                   = "tunetrail"
+  username               = "tunetrail"
+  password               = var.db_password
+  parameter_group_name   = "default.postgres15"
+  db_subnet_group_name   = aws_db_subnet_group.tunetrail.name
+  publicly_accessible    = false # インターネットからの直接のアクセスを拒否
+  skip_final_snapshot    = true  # 削除時にスナップショットを作成しない
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
 }

--- a/infra/security_group.tf
+++ b/infra/security_group.tf
@@ -27,10 +27,10 @@ resource "aws_security_group" "sg" {
   description = "Security Group for ECS Tasks"
   vpc_id      = aws_vpc.main.id
 
-  # DBへのアクセス用のインバウンドルールの設定
+  # ECSタスクへのアクセス用のインバウンドルールの設定
   ingress {
-    from_port   = 5432 # DBのポート番号
-    to_port     = 5432
+    from_port   = 80 # APIのポート番号
+    to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
   }
@@ -39,6 +39,29 @@ resource "aws_security_group" "sg" {
   ingress {
     from_port   = 443
     to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
+  }
+
+  # アウトバウンドルールの設定
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # 任意のIPへのアクセスを許可
+  }
+}
+
+# RDS用のセキュリティグループ
+resource "aws_security_group" "rds_sg" {
+  name        = "rds_sg"
+  description = "Security Group for RDS Instance"
+  vpc_id      = aws_vpc.main.id
+
+  # RDSへのアクセス用のインバウンドルールの設定
+  ingress {
+    from_port   = 5432 # DBのポート番号
+    to_port     = 5432
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
   }


### PR DESCRIPTION
## 概要

AWS上でRDSインスタンスとAPIコンテナが疎通できない問題を修正しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] APIのタスク定義に環境変数の設定漏れがあったので修正しました。
- [ ] RDSインスタンス用のセキュリティグループを追加しました。
- [ ] ECSタスクのセキュリティグループのインバウンドルールに誤りがあったので修正しました。

## 動作確認

`terraform apply`でRDSとAPIコンテナが疎通できることを確認しました。

## 影響範囲

AWSとRDSとAPIコンテナが疎通できるようになります。その他のコードへの影響はありません。

## 補足

疎通できることは確認できましたが、postgresから`pg_hba.conf`のエラーが出ています。
