### PR TITLE
PostgresとSSLで通信するように修正

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -4,6 +4,8 @@ import (
 	"github.com/caarlos0/env/v6"
 )
 
+// Configは環境変数から取得する設定を表す
+// デフォルトの値は開発環境用の値
 type Config struct {
 	Env        string `env:"TUNETRAIL_ENV" envDefault:"dev"`
 	Port       int    `env:"PORT" envDefault:"8080"`
@@ -14,6 +16,7 @@ type Config struct {
 	DBName     string `env:"TUNETRAIL_DB_NAME" envDefault:"tunetrail"`
 }
 
+// Newは環境変数から設定を取得してConfigを返す
 func New() (*Config, error) {
 	cfg := &Config{}
 	if err := env.Parse(cfg); err != nil {

--- a/api/store/repository.go
+++ b/api/store/repository.go
@@ -46,11 +46,17 @@ func New(cfg *config.Config) (*sqlx.DB, func(), error) {
 	log.Print("store: start store.New")
 	log.Print("store: open db")
 	log.Printf("store: db host: %s db port: %v db user: %s db name: %s", cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBName)
+
 	driver := "postgres"
+
+	sslMode := "require"
+	if cfg.Env == "dev" {
+		sslMode = "disable" // 開発環境の場合はSSL通信を無効にする
+	}
+
 	db, err := sql.Open(driver, fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		cfg.DBHost, cfg.DBPort, cfg.DBUser,
-		cfg.DBPassword, cfg.DBName,
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		cfg.DBHost, cfg.DBPort, cfg.DBUser, cfg.DBPassword, cfg.DBName, sslMode,
 	))
 	if err != nil {
 		log.Printf("store: failed to open db: %v", err)


### PR DESCRIPTION
## 概要

RDSのPostgresとAPIがSSLで通信するように修正しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] 開発環境以外でPostgresとSSL接続するように接続文字列を変更しました。
- [ ] `config`パッケージにコメントを追加しました。

## 動作確認

- [ ] 全てのユニットテストが成功することを確認しました。

## 追加タスク

PostgresとAPIがSSLで通信できているかAWS Management Consoleで確認してください。

## 影響範囲

PostgresとAPIがSSLで通信できるようになります。その他のコードへの影響はありません。
