### PR TITLE
フロントエンドのネットワーク設定を追加

### DIFF
--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -40,6 +40,24 @@ resource "aws_lb_listener" "https" {
   }
 }
 
+# Frontend用のリスナールール
+# Frontendのドメインにアクセスした場合に、Frontend用のターゲットグループにフォワードする
+resource "aws_lb_listener_rule" "frontend" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 101
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.alb_tg_frontend.arn
+  }
+
+  condition {
+    host_header {
+      values = [var.frontend_domain]
+    }
+  }
+}
+
 # API用のリスナールール
 # apiのドメインにアクセスした場合に、API用のターゲットグループにフォワードする
 resource "aws_lb_listener_rule" "api" {
@@ -67,6 +85,26 @@ resource "aws_lb_target_group" "alb_tg" {
   vpc_id   = aws_vpc.main.id # VPCを指定
 }
 
+# Frontend用のターゲットグループ
+resource "aws_lb_target_group" "alb_tg_frontend" {
+  name        = "frontend-target-group"
+  port        = var.frontend_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id # VPCを指定
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2  # 2回連続で正常なレスポンスを返すとヘルスチェックをパス
+    unhealthy_threshold = 2  # 2回連続で異常なレスポンスを返すとヘルスチェックを不合格
+    timeout             = 5  # 5秒以内にレスポンスを返さない場合はヘルスチェックを不合格
+    interval            = 30 # 30秒ごとにヘルスチェックを実施
+    path                = "/health"
+    matcher             = "200-399" # 200番台と300番台のレスポンスを正常とする
+    port                = var.frontend_port
+    protocol            = "HTTP"
+  }
+}
 
 # API用のターゲットグループ
 resource "aws_lb_target_group" "alb_tg_api" {

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -41,7 +41,7 @@ resource "aws_lb_listener" "https" {
 }
 
 # API用のリスナールール
-# api.tune-trail.comにアクセスした場合に、API用のターゲットグループにフォワードする
+# apiのドメインにアクセスした場合に、API用のターゲットグループにフォワードする
 resource "aws_lb_listener_rule" "api" {
   listener_arn = aws_lb_listener.https.arn
   priority     = 100
@@ -53,7 +53,7 @@ resource "aws_lb_listener_rule" "api" {
 
   condition {
     host_header {
-      values = ["api.tune-trail.com"]
+      values = [var.api_domain]
     }
   }
 }
@@ -62,7 +62,7 @@ resource "aws_lb_listener_rule" "api" {
 # デフォルトではフロントエンドに接続する
 resource "aws_lb_target_group" "alb_tg" {
   name     = "default-target-group"
-  port     = 3000
+  port     = var.frontend_port
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id # VPCを指定
 }
@@ -71,7 +71,7 @@ resource "aws_lb_target_group" "alb_tg" {
 # API用のターゲットグループ
 resource "aws_lb_target_group" "alb_tg_api" {
   name        = "api-target-group"
-  port        = 80
+  port        = var.api_port
   protocol    = "HTTP"
   vpc_id      = aws_vpc.main.id # VPCを指定
   target_type = "ip"
@@ -84,8 +84,7 @@ resource "aws_lb_target_group" "alb_tg_api" {
     interval            = 30 # 30秒ごとにヘルスチェックを実施
     path                = "/health"
     matcher             = "200-399" # 200番台と300番台のレスポンスを正常とする
-    port                = 80
+    port                = var.api_port
     protocol            = "HTTP"
   }
 }
-

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "api" {
   load_balancer {
     target_group_arn = aws_lb_target_group.alb_tg_api.arn
     container_name   = "tunetrail-api"
-    container_port   = 80
+    container_port   = var.api_port
   }
 }
 
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "api" {
     name  = "tunetrail-api",
     image = "${aws_ecr_repository.api.repository_url}:${var.api_image_tag}", # ECRのリポジトリURL
     portMappings = [{
-      containerPort = 80
+      containerPort = var.api_port
       protocol      = "tcp"
     }],
     environment = [
@@ -104,7 +104,7 @@ resource "aws_ecs_task_definition" "frontend" {
     name  = "tunetrail-frontend",
     image = "${aws_ecr_repository.frontend.repository_url}:latest",
     portMappings = [{
-      containerPort = 3000
+      containerPort = var.frontend_port
     }],
     environment = [
       {

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -8,12 +8,11 @@ resource "aws_ecs_service" "api" {
   name            = "tunetrail-api"
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.api.arn
-  desired_count   = 2 # タスクの数
-  # desired_count = 0 # 一時的に無効化する場合は0にする
-  launch_type = "FARGATE"
+  desired_count   = var.use_resources ? 2 : 0 # タスクの数
+  launch_type     = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
-    security_groups  = [aws_security_group.sg.id]
+    security_groups  = [aws_security_group.api_sg.id]
     assign_public_ip = false
   }
   # ロードバランサーの設定
@@ -88,12 +87,11 @@ resource "aws_ecs_service" "frontend" {
   name            = "tunetrail-frontend"
   cluster         = aws_ecs_cluster.tunetrail.id
   task_definition = aws_ecs_task_definition.frontend.arn
-  desired_count   = 2
-  # desired_count = 0 # 一時的に無効化する場合は0にする
-  launch_type = "FARGATE"
+  desired_count   = var.use_resources ? 2 : 0 # タスクの数
+  launch_type     = "FARGATE"
   network_configuration {
     subnets          = [aws_subnet.private1.id, aws_subnet.private2.id]
-    security_groups  = [aws_security_group.sg.id]
+    security_groups  = [aws_security_group.frontend_sg.id]
     assign_public_ip = false
   }
 }
@@ -102,7 +100,7 @@ resource "aws_ecs_service" "frontend" {
 resource "aws_ecs_task_definition" "frontend" {
   container_definitions = jsonencode([{
     name  = "tunetrail-frontend",
-    image = "${aws_ecr_repository.frontend.repository_url}:latest",
+    image = "${aws_ecr_repository.frontend.repository_url}:${var.frontend_image_tag}",
     portMappings = [{
       containerPort = var.frontend_port
     }],

--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -45,7 +45,7 @@ resource "aws_acm_certificate_validation" "cert" {
 # ALBへのエイリアスレコード (www)
 resource "aws_route53_record" "www" {
   zone_id = aws_route53_zone.tunetrail.zone_id
-  name    = "www.tune-trail.com"
+  name    = var.frontend_domain
   type    = "A"
 
   alias {
@@ -58,7 +58,7 @@ resource "aws_route53_record" "www" {
 # ALBへのエイリアスレコード (api)
 resource "aws_route53_record" "api" {
   zone_id = aws_route53_zone.tunetrail.zone_id
-  name    = "api.tune-trail.com"
+  name    = var.api_domain
   type    = "A"
 
   alias {

--- a/infra/security_group.tf
+++ b/infra/security_group.tf
@@ -29,15 +29,46 @@ resource "aws_security_group" "alb_sg" {
   }
 }
 
-# ECSタスク用のセキュリティグループ
-resource "aws_security_group" "sg" {
-  name        = "ecs_tasks_sg"
-  description = "Security Group for ECS Tasks"
+# Frontend用のセキュリティグループ
+resource "aws_security_group" "frontend_sg" {
+  name        = "frontend_sg"
+  description = "Security Group for Frontend Tasks"
   vpc_id      = aws_vpc.main.id
 
-  # ECSタスクへのアクセス用のインバウンドルールの設定
+  # APIへのアクセス用のインバウンドルールの設定
   ingress {
-    from_port   = var.api_port # APIのポート番号
+    from_port   = var.frontend_port
+    to_port     = var.frontend_port
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
+  }
+
+  # VPCエンドポイント用のインバウンドルールの設定
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
+  }
+
+  # アウトバウンドルールの設定
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"] # 任意のIPへのアクセスを許可
+  }
+}
+
+# API用のセキュリティグループ
+resource "aws_security_group" "api_sg" {
+  name        = "api_sg"
+  description = "Security Group for API Tasks"
+  vpc_id      = aws_vpc.main.id
+
+  # APIへのアクセス用のインバウンドルールの設定
+  ingress {
+    from_port   = var.api_port
     to_port     = var.api_port
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可

--- a/infra/security_group.tf
+++ b/infra/security_group.tf
@@ -6,8 +6,8 @@ resource "aws_security_group" "alb_sg" {
 
   # HTTPに対するインバウンドルール
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = var.api_port
+    to_port     = var.api_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"] # 任意のIPからのアクセスを許可
   }
@@ -37,8 +37,8 @@ resource "aws_security_group" "sg" {
 
   # ECSタスクへのアクセス用のインバウンドルールの設定
   ingress {
-    from_port   = 80 # APIのポート番号
-    to_port     = 80
+    from_port   = var.api_port # APIのポート番号
+    to_port     = var.api_port
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
   }
@@ -68,8 +68,8 @@ resource "aws_security_group" "rds_sg" {
 
   # RDSへのアクセス用のインバウンドルールの設定
   ingress {
-    from_port   = 5432 # DBのポート番号
-    to_port     = 5432
+    from_port   = var.db_port # DBのポート番号
+    to_port     = var.db_port
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"] # VPC内からのアクセスのみ許可
   }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,3 +1,15 @@
+# 無駄な課金を防ぐために、リソースを使用しない間はfalseにする。
+variable "use_resources" {
+  description = "Whether to use resources or data sources"
+  type        = bool
+  default     = true
+}
+
+variable "frontend_image_tag" {
+  description = "value of the tag for the frontend image"
+  type        = string
+}
+
 variable "api_image_tag" {
   description = "value of the tag for the API image"
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,9 +1,3 @@
-variable "api_domain" {
-  description = "The domain name for the API"
-  type        = string
-  default     = "api.tune-trail.com"
-}
-
 variable "api_image_tag" {
   description = "value of the tag for the API image"
   type        = string
@@ -12,4 +6,34 @@ variable "api_image_tag" {
 variable "db_password" {
   description = "The password for the DB instance"
   type        = string
+}
+
+variable "frontend_domain" {
+  description = "The domain name for the frontend"
+  type        = string
+  default     = "www.tune-trail.com"
+}
+
+variable "frontend_port" {
+  description = "The port for the frontend"
+  type        = number
+  default     = 3000
+}
+
+variable "api_domain" {
+  description = "The domain name for the API"
+  type        = string
+  default     = "api.tune-trail.com"
+}
+
+variable "api_port" {
+  description = "The port for the API"
+  type        = number
+  default     = 80
+}
+
+variable "db_port" {
+  description = "The port for the DB"
+  type        = number
+  default     = 5432
 }

--- a/infra/vpc_endpoints.tf
+++ b/infra/vpc_endpoints.tf
@@ -1,30 +1,30 @@
 # ECRのAPIを呼び出すためのVPCエンドポイント
 # イメージのメタデータを取得したり、イメージの認証トークンを取得するために使用される。
 resource "aws_vpc_endpoint" "ecr_api" {
-  # count               = 0 # 一時的に無効化する場合は0にする
+  count               = var.use_resources ? 1 : 0
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
-  security_group_ids  = [aws_security_group.sg.id]
+  security_group_ids  = [aws_security_group.api_sg.id, aws_security_group.frontend_sg.id]
   private_dns_enabled = true
 }
 
 # Dockerイメージのプッシュ/プルを行うためのVPCエンドポイント
 resource "aws_vpc_endpoint" "ecr_dkr" {
-  # count               = 0 # 一時的に無効化する場合は0にする
+  count               = var.use_resources ? 1 : 0
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
-  security_group_ids  = [aws_security_group.sg.id]
+  security_group_ids  = [aws_security_group.api_sg.id, aws_security_group.frontend_sg.id]
   private_dns_enabled = true
 }
 
 # S3用のVPCエンドポイント
 # ECRのイメージをプッシュ/プルする際に、S3のバケットを使用するために必要。
 resource "aws_vpc_endpoint" "s3" {
-  # count             = 0 # 一時的に無効化する場合は0にする
+  count             = var.use_resources ? 1 : 0
   vpc_id            = aws_vpc.main.id
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = "Gateway"
@@ -33,12 +33,12 @@ resource "aws_vpc_endpoint" "s3" {
 
 # CloudWatch Logs用のVPCエンドポイント
 resource "aws_vpc_endpoint" "cloudwatch_logs" {
-  # count               = 0 # 一時的に無効化する場合は0にする
+  count               = var.use_resources ? 1 : 0
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.ap-northeast-1.logs"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.private1.id, aws_subnet.private2.id]
-  security_group_ids  = [aws_security_group.sg.id]
+  security_group_ids  = [aws_security_group.api_sg.id, aws_security_group.frontend_sg.id]
   private_dns_enabled = true
 }
 


### PR DESCRIPTION
## 概要

フロントエンドのAWSリソースに不備があったので追加しました。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] フロントエンド用のリスナールールを追加しました。
- [ ] フロントエンド用のターゲットグループを追加しました。
- [ ] API用のセキュリティグループを追加しました。
- [ ] 既存のECSタスクで共有するセキュリティグループを削除しました。
- [ ] ECSタスクに割り当てるドメインとポート番号を変数化しました。
- [ ] リソースの使用をトグルするための変数を追加しました。
- [ ] 不正確なコメントを修正しました。

## 動作確認

- `terraform plan`で期待通りの結果が出力されることを確認しました。
- `terraform apply`で期待通りの結果になることを確認しました。

