### PR TITLE
HealthページをSSRに変更

### DIFF
--- a/frontend/lib/getHealth.ts
+++ b/frontend/lib/getHealth.ts
@@ -1,11 +1,21 @@
 import { ApiContext, Health } from "@/types"
 
-import { fetchJson } from "./fetchJson"
 import { HealthSchema } from "./validations/health.schema"
 
 // getHealthはAPIの稼働状態を取得する
 export const getHealth = async (context: ApiContext): Promise<Health> => {
-  const data: unknown = await fetchJson(`${context.apiRoot}/health`)
+  const response = await fetch(`${context.apiRoot}/health`, {
+    cache: "no-store",
+  })
+  if (!response.ok) {
+    const errorResponse = await response.json()
+    const error = new Error(
+      errorResponse.message ?? "Failed to fetch data from the API."
+    )
+    throw error
+  }
+
+  const data = await response.json()
   if (!data) {
     throw new Error("Failed to fetch data from the API.")
   }


### PR DESCRIPTION
## 概要

ヘルスチェックページをSSRに変更しました。これは、ヘルスチェックページをSGページで実装していたため、Next.jsコンテナのビルド後にAPIコンテナが落ちた場合に古い状態が表示されてしまう問題を解消するためです。

## 関連Issue

関連するIssueはありません。

## 変更点

- [ ] `fetchJson`ではなく`fetch`を使用するように変更しました。
- [ ] `fetch`の引数に`{ cache: "no-store" }`を追加しました。

