### PR TITLE
DNS lookupの処理を追加

### DIFF
--- a/frontend/lib/getHealth.ts
+++ b/frontend/lib/getHealth.ts
@@ -1,9 +1,21 @@
+import dns from "dns"
 import { ApiContext, Health } from "@/types"
 
 import { HealthSchema } from "./validations/health.schema"
 
 // getHealthはAPIの稼働状態を取得する
 export const getHealth = async (context: ApiContext): Promise<Health> => {
+  // DNSのlookupを行う
+  const apiHost = context.apiRoot.replace(/^https:\/\//, "")
+  console.log(`looking up ${apiHost}`)
+  dns.lookup(apiHost, (err, address, family) => {
+    if (err) {
+      console.error(err)
+      return
+    }
+    console.log(`address: ${address} family: IPv${family}`)
+  })
+
   console.log(`fetching ${context.apiRoot}/health`)
   try {
     const response = await fetch(`${context.apiRoot}/health`, {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,5 @@
 /** @type {import('next').NextConfig} */
 
-const dns = require("dns")
-
-dns.setDefaultResultOrder("ipv4first")
-
 const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
## 概要

AWS上でのAPIへの接続状況を確認するためにDNS lookupの処理を追加しました。

## 変更点

- [ ] DNS lookupの処理を追加しました。
- [ ] IPv4の設定は効果がなかったので削除しました。

