### PR TITLE
確認用パスワードを送信しないように変更・その他軽微なバグ修正

### DIFF
--- a/frontend/components/containers/SignupForm/SignupForm.test.tsx
+++ b/frontend/components/containers/SignupForm/SignupForm.test.tsx
@@ -50,7 +50,7 @@ describe("SignupForm", () => {
 
     // フォームに入力
     // Inputコンポーネントのプレースホルダーは内部的にlabelを使用しているため、
-    // getByPlaceholderTextで取得する
+    // getByLabelTextで取得する
     fireEvent.change(screen.getByLabelText("アカウント名"), {
       target: { value: "testname" },
     })

--- a/frontend/components/containers/SignupForm/SignupForm.tsx
+++ b/frontend/components/containers/SignupForm/SignupForm.tsx
@@ -18,7 +18,6 @@ export interface SignupFormProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 type FormData = z.infer<typeof userAuthSchema>
 
-// 登録ボタン押下時の処理
 export const SignupForm: React.FC<SignupFormProps> = ({
   className,
   ...props
@@ -29,6 +28,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const { showToast } = useToast()
 
+  // 登録ボタン押下時の処理
   const onSubmit = async (data: FormData) => {
     setIsLoading(true)
 
@@ -36,8 +36,13 @@ export const SignupForm: React.FC<SignupFormProps> = ({
       setIsLoading(false)
       return
     }
-    const error = await signup(apiContext, data)
 
+    const error = await signup(apiContext, {
+      userName: data.userName,
+      name: data.name,
+      password: data.password,
+      email: data.email,
+    })
     if (error) {
       showToast({
         intent: "error",

--- a/frontend/services/auth/signup.ts
+++ b/frontend/services/auth/signup.ts
@@ -28,7 +28,7 @@ export const signup = async (
   data: SignupData
 ): Promise<null | FetchError> => {
   try {
-    const response = await fetch(`${context.apiRoot}/register`, {
+    const response = await fetch(`${context.apiRoot}/user/register`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## 変更点

- 確認用パスワードをAPIに送信しないように変更
- コメントの誤りを修正
- APIエンドポイントのパスの誤りを修正