### PR TITLE
migrateのベースイメージを変更

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -2,7 +2,7 @@
 
 # ---------------------------------------------------
 # リリース用のコンテナイメージを作成するステージ
-FROM golang:1.20.3-alpine as deploy
+FROM golang:1.20.3-bullseye as deploy
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

`alpine`ではGitHub Actions上でのイメージビルドに失敗するので、`bullseye`に変更