### PR TITLE
`auth.SignUp()`がCognitoにアクセスできない不具合を修正

### DIFF
--- a/restapi/config/config.go
+++ b/restapi/config/config.go
@@ -7,16 +7,17 @@ import (
 // Configは環境変数から取得する設定を表す
 // デフォルトの値は開発環境用の値
 type Config struct {
-	Env               string `env:"TUNETRAIL_ENV" envDefault:"dev"`
-	Port              int    `env:"PORT" envDefault:"8080"`
-	DBHost            string `env:"TUNETRAIL_DB_HOST" envDefault:"tunetrail-db"`
-	DBPort            int    `env:"TUNETRAIL_DB_PORT" envDefault:"5432"`
-	DBUser            string `env:"TUNETRAIL_DB_USER" envDefault:"tunetrail"`
-	DBPassword        string `env:"TUNETRAIL_DB_PASSWORD" envDefault:"tunetrail"`
-	DBName            string `env:"TUNETRAIL_DB_NAME" envDefault:"tunetrail"`
-	AWSRegion         string `env:"TUNETRAIL_AWS_REGION" envDefault:"ap-northeast-1"`
-	CognitoUserPoolId string `env:"COGNITO_USER_POOL_ID" envDefault:""`
-	CognitoClientId   string `env:"COGNITO_CLIENT_ID" envDefault:""`
+	Env                 string `env:"TUNETRAIL_ENV" envDefault:"dev"`
+	Port                int    `env:"PORT" envDefault:"8080"`
+	DBHost              string `env:"TUNETRAIL_DB_HOST" envDefault:"tunetrail-db"`
+	DBPort              int    `env:"TUNETRAIL_DB_PORT" envDefault:"5432"`
+	DBUser              string `env:"TUNETRAIL_DB_USER" envDefault:"tunetrail"`
+	DBPassword          string `env:"TUNETRAIL_DB_PASSWORD" envDefault:"tunetrail"`
+	DBName              string `env:"TUNETRAIL_DB_NAME" envDefault:"tunetrail"`
+	AWSRegion           string `env:"TUNETRAIL_AWS_REGION" envDefault:"ap-northeast-1"`
+	CognitoUserPoolId   string `env:"COGNITO_USER_POOL_ID" envDefault:""`
+	CognitoClientId     string `env:"COGNITO_CLIENT_ID" envDefault:""`
+	CognitoClientSecret string `env:"COGNITO_CLIENT_SECRET" envDefault:""`
 }
 
 // Newは環境変数から設定を取得してConfigを返す

--- a/restapi/go.mod
+++ b/restapi/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-playground/validator/v10 v10.11.2
+	github.com/google/uuid v1.3.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.7
 	github.com/matryer/moq v0.3.1

--- a/restapi/go.sum
+++ b/restapi/go.sum
@@ -41,6 +41,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/restapi/router/router.go
+++ b/restapi/router/router.go
@@ -19,7 +19,9 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 		return nil, cleanup, err
 	}
 
-	a := auth.NewAuth(cfg.AWSRegion, cfg.CognitoUserPoolId, cfg.CognitoClientId)
+	a := auth.NewAuth(
+		cfg.AWSRegion, cfg.CognitoUserPoolId, cfg.CognitoClientId, cfg.CognitoClientSecret,
+	)
 
 	cl := clock.RealClocker{}
 


### PR DESCRIPTION
## 変更点

- ClientSecretからSecretHashを生成する実装が漏れていたので追加。
- メールアドレスをエイリアスにしている場合、メールアドレスをユーザー名として登録できない。そこで、Cognito内でのみユーザー名としてUUIDを使用するように変更。