### PR TITLE
ConfirmSignup関数を追加・Repositoryをリファクタリング

### DIFF
--- a/restapi/auth/moq_test.go
+++ b/restapi/auth/moq_test.go
@@ -23,6 +23,9 @@ var _ AuthProvider = &AuthProviderMock{}
 //			AdminInitiateAuthFunc: func(input *cognitoidentityprovider.AdminInitiateAuthInput) (*cognitoidentityprovider.AdminInitiateAuthOutput, error) {
 //				panic("mock out the AdminInitiateAuth method")
 //			},
+//			ConfirmSignUpWithContextFunc: func(ctx context.Context, input *cognitoidentityprovider.ConfirmSignUpInput, opts ...request.Option) (*cognitoidentityprovider.ConfirmSignUpOutput, error) {
+//				panic("mock out the ConfirmSignUpWithContext method")
+//			},
 //			SignUpWithContextFunc: func(ctx context.Context, input *cognitoidentityprovider.SignUpInput, opts ...request.Option) (*cognitoidentityprovider.SignUpOutput, error) {
 //				panic("mock out the SignUpWithContext method")
 //			},
@@ -36,6 +39,9 @@ type AuthProviderMock struct {
 	// AdminInitiateAuthFunc mocks the AdminInitiateAuth method.
 	AdminInitiateAuthFunc func(input *cognitoidentityprovider.AdminInitiateAuthInput) (*cognitoidentityprovider.AdminInitiateAuthOutput, error)
 
+	// ConfirmSignUpWithContextFunc mocks the ConfirmSignUpWithContext method.
+	ConfirmSignUpWithContextFunc func(ctx context.Context, input *cognitoidentityprovider.ConfirmSignUpInput, opts ...request.Option) (*cognitoidentityprovider.ConfirmSignUpOutput, error)
+
 	// SignUpWithContextFunc mocks the SignUpWithContext method.
 	SignUpWithContextFunc func(ctx context.Context, input *cognitoidentityprovider.SignUpInput, opts ...request.Option) (*cognitoidentityprovider.SignUpOutput, error)
 
@@ -45,6 +51,15 @@ type AuthProviderMock struct {
 		AdminInitiateAuth []struct {
 			// Input is the input argument value.
 			Input *cognitoidentityprovider.AdminInitiateAuthInput
+		}
+		// ConfirmSignUpWithContext holds details about calls to the ConfirmSignUpWithContext method.
+		ConfirmSignUpWithContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Input is the input argument value.
+			Input *cognitoidentityprovider.ConfirmSignUpInput
+			// Opts is the opts argument value.
+			Opts []request.Option
 		}
 		// SignUpWithContext holds details about calls to the SignUpWithContext method.
 		SignUpWithContext []struct {
@@ -56,8 +71,9 @@ type AuthProviderMock struct {
 			Opts []request.Option
 		}
 	}
-	lockAdminInitiateAuth sync.RWMutex
-	lockSignUpWithContext sync.RWMutex
+	lockAdminInitiateAuth        sync.RWMutex
+	lockConfirmSignUpWithContext sync.RWMutex
+	lockSignUpWithContext        sync.RWMutex
 }
 
 // AdminInitiateAuth calls AdminInitiateAuthFunc.
@@ -89,6 +105,46 @@ func (mock *AuthProviderMock) AdminInitiateAuthCalls() []struct {
 	mock.lockAdminInitiateAuth.RLock()
 	calls = mock.calls.AdminInitiateAuth
 	mock.lockAdminInitiateAuth.RUnlock()
+	return calls
+}
+
+// ConfirmSignUpWithContext calls ConfirmSignUpWithContextFunc.
+func (mock *AuthProviderMock) ConfirmSignUpWithContext(ctx context.Context, input *cognitoidentityprovider.ConfirmSignUpInput, opts ...request.Option) (*cognitoidentityprovider.ConfirmSignUpOutput, error) {
+	if mock.ConfirmSignUpWithContextFunc == nil {
+		panic("AuthProviderMock.ConfirmSignUpWithContextFunc: method is nil but AuthProvider.ConfirmSignUpWithContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Input *cognitoidentityprovider.ConfirmSignUpInput
+		Opts  []request.Option
+	}{
+		Ctx:   ctx,
+		Input: input,
+		Opts:  opts,
+	}
+	mock.lockConfirmSignUpWithContext.Lock()
+	mock.calls.ConfirmSignUpWithContext = append(mock.calls.ConfirmSignUpWithContext, callInfo)
+	mock.lockConfirmSignUpWithContext.Unlock()
+	return mock.ConfirmSignUpWithContextFunc(ctx, input, opts...)
+}
+
+// ConfirmSignUpWithContextCalls gets all the calls that were made to ConfirmSignUpWithContext.
+// Check the length with:
+//
+//	len(mockedAuthProvider.ConfirmSignUpWithContextCalls())
+func (mock *AuthProviderMock) ConfirmSignUpWithContextCalls() []struct {
+	Ctx   context.Context
+	Input *cognitoidentityprovider.ConfirmSignUpInput
+	Opts  []request.Option
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Input *cognitoidentityprovider.ConfirmSignUpInput
+		Opts  []request.Option
+	}
+	mock.lockConfirmSignUpWithContext.RLock()
+	calls = mock.calls.ConfirmSignUpWithContext
+	mock.lockConfirmSignUpWithContext.RUnlock()
 	return calls
 }
 

--- a/restapi/service/auth.go
+++ b/restapi/service/auth.go
@@ -8,24 +8,15 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/kngnkg/tunetrail/restapi/auth"
 	"github.com/kngnkg/tunetrail/restapi/model"
-	"github.com/kngnkg/tunetrail/restapi/store"
 )
 
-// var (
-// // エラー
-// )
-
 type AuthService struct {
-	DB   store.Beginner
+	DB   *sqlx.DB
 	Repo UserRepository
 	Auth Auth
 }
 
 // type Token struct{}
-
-type Auth interface {
-	SignUp(ctx context.Context, email, password string) (string, error)
-}
 
 // RegisterUserはユーザーを登録する
 func (as *AuthService) RegisterUser(ctx context.Context, data *model.UserRegistrationData) (*model.User, error) {

--- a/restapi/service/auth.go
+++ b/restapi/service/auth.go
@@ -8,10 +8,11 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/kngnkg/tunetrail/restapi/auth"
 	"github.com/kngnkg/tunetrail/restapi/model"
+	"github.com/kngnkg/tunetrail/restapi/store"
 )
 
 type AuthService struct {
-	DB   *sqlx.DB
+	DB   store.DBConnection
 	Repo UserRepository
 	Auth Auth
 }

--- a/restapi/service/auth_test.go
+++ b/restapi/service/auth_test.go
@@ -26,7 +26,7 @@ type AuthServiceTestSuite struct {
 
 func TestAuthServiceTestSuite(t *testing.T) {
 	t.Parallel()
-	moqDB := &BeginnerMock{}
+	moqDB := &DBConnectionMock{}
 	moqRepo := &UserRepositoryMock{}
 	moqAuth := &AuthMock{}
 	fc := &clock.FixedClocker{}
@@ -73,7 +73,7 @@ func TestAuthServiceTestSuite(t *testing.T) {
 		return nil
 	}
 
-	moqRepo.RegisterUserFunc = func(ctx context.Context, db store.Queryer, u *model.User) error {
+	moqRepo.RegisterUserFunc = func(ctx context.Context, db store.Execer, u *model.User) error {
 		// ダミーの値を設定
 		u.Id = "1"
 		u.CreatedAt = fc.Now()

--- a/restapi/service/errors.go
+++ b/restapi/service/errors.go
@@ -1,0 +1,16 @@
+package service
+
+import "errors"
+
+var (
+	// ユーザー名が既に存在する
+	ErrUserNameAlreadyExists = errors.New("service: user name already exists")
+	// メールアドレスが既に存在する
+	ErrEmailAlreadyExists = errors.New("service: email already exists")
+	// ユーザーが存在しない
+	ErrUserNotFound = errors.New("service: user not found")
+	// 検証コードが一致しない
+	ErrCodeMismatch = errors.New("service: code mismatch")
+	// 検証コードが期限切れ
+	ErrCodeExpired = errors.New("service: code expired")
+)

--- a/restapi/service/gen_moq_test.go
+++ b/restapi/service/gen_moq_test.go
@@ -2,4 +2,4 @@ package service
 
 //go:generate go run github.com/matryer/moq -out moq_test.go . HealthRepository UserRepository Auth
 
-//go:generate go run github.com/matryer/moq -out store_moq_test.go -skip-ensure -pkg service ../store Beginner Preparer Queryer
+//go:generate go run github.com/matryer/moq -out store_moq_test.go -skip-ensure -pkg service ../store DBConnection Beginner Preparer Queryer

--- a/restapi/service/health.go
+++ b/restapi/service/health.go
@@ -10,7 +10,7 @@ import (
 )
 
 type HealthService struct {
-	DB   store.Queryer
+	DB   store.DBConnection
 	Repo HealthRepository
 }
 

--- a/restapi/service/health.go
+++ b/restapi/service/health.go
@@ -9,10 +9,6 @@ import (
 	"github.com/kngnkg/tunetrail/restapi/store"
 )
 
-type HealthRepository interface {
-	Ping(ctx context.Context, db store.Queryer) error
-}
-
 type HealthService struct {
 	DB   store.Queryer
 	Repo HealthRepository

--- a/restapi/service/health_test.go
+++ b/restapi/service/health_test.go
@@ -45,7 +45,7 @@ func TestHealthService_HealthCheck(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			moqDB := &QueryerMock{}
+			moqDB := &DBConnectionMock{}
 			moqRepo := &HealthRepositoryMock{}
 			moqRepo.PingFunc = func(ctx context.Context, db store.Queryer) error {
 				if tt.name == "errCannotCommunicateWithDB" {

--- a/restapi/service/interfaces.go
+++ b/restapi/service/interfaces.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/kngnkg/tunetrail/restapi/model"
+	"github.com/kngnkg/tunetrail/restapi/store"
+)
+
+type Auth interface {
+	SignUp(ctx context.Context, email, password string) (string, error)
+	ConfirmSignUp(ctx context.Context, cognitoUserName, code string) error
+}
+
+type UserRepository interface {
+	// WithTransactionはトランザクションを実行する
+	WithTransaction(ctx context.Context, db store.Beginner, f func(tx *sqlx.Tx) error) error
+	// RegisterUserはユーザーを登録する
+	// RegisterUserInfo
+	RegisterUser(ctx context.Context, db store.Queryer, u *model.User) error
+	// UserExistsByUserNameはユーザー名が既に存在するかどうかを返す
+	UserExistsByUserName(ctx context.Context, db store.Queryer, userName string) (bool, error)
+	// GetUserByUserNameはユーザー名からユーザーを取得する
+	GetUserByUserName(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
+	// UpdateUserはユーザーを更新する
+	UpdateUser(ctx context.Context, db store.Queryer, u *model.User) error
+	// DeleteUserByUserNameはユーザー名からユーザーを削除する
+	DeleteUserByUserName(ctx context.Context, db store.Queryer, userName string) error
+}
+
+type HealthRepository interface {
+	Ping(ctx context.Context, db store.Queryer) error
+}

--- a/restapi/service/interfaces.go
+++ b/restapi/service/interfaces.go
@@ -16,17 +16,17 @@ type Auth interface {
 type UserRepository interface {
 	// WithTransactionはトランザクションを実行する
 	WithTransaction(ctx context.Context, db store.Beginner, f func(tx *sqlx.Tx) error) error
-	// RegisterUserはユーザーを登録する
-	// RegisterUserInfo
-	RegisterUser(ctx context.Context, db store.Queryer, u *model.User) error
 	// UserExistsByUserNameはユーザー名が既に存在するかどうかを返す
 	UserExistsByUserName(ctx context.Context, db store.Queryer, userName string) (bool, error)
 	// GetUserByUserNameはユーザー名からユーザーを取得する
 	GetUserByUserName(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
+	// RegisterUserはユーザーを登録する
+	// RegisterUserInfo
+	RegisterUser(ctx context.Context, db store.Execer, u *model.User) error
 	// UpdateUserはユーザーを更新する
-	UpdateUser(ctx context.Context, db store.Queryer, u *model.User) error
+	UpdateUser(ctx context.Context, db store.Execer, u *model.User) error
 	// DeleteUserByUserNameはユーザー名からユーザーを削除する
-	DeleteUserByUserName(ctx context.Context, db store.Queryer, userName string) error
+	DeleteUserByUserName(ctx context.Context, db store.Execer, userName string) error
 }
 
 type HealthRepository interface {

--- a/restapi/service/moq_test.go
+++ b/restapi/service/moq_test.go
@@ -93,16 +93,16 @@ var _ UserRepository = &UserRepositoryMock{}
 //
 //		// make and configure a mocked UserRepository
 //		mockedUserRepository := &UserRepositoryMock{
-//			DeleteUserByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) error {
+//			DeleteUserByUserNameFunc: func(ctx context.Context, db store.Execer, userName string) error {
 //				panic("mock out the DeleteUserByUserName method")
 //			},
 //			GetUserByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) (*model.User, error) {
 //				panic("mock out the GetUserByUserName method")
 //			},
-//			RegisterUserFunc: func(ctx context.Context, db store.Queryer, u *model.User) error {
+//			RegisterUserFunc: func(ctx context.Context, db store.Execer, u *model.User) error {
 //				panic("mock out the RegisterUser method")
 //			},
-//			UpdateUserFunc: func(ctx context.Context, db store.Queryer, u *model.User) error {
+//			UpdateUserFunc: func(ctx context.Context, db store.Execer, u *model.User) error {
 //				panic("mock out the UpdateUser method")
 //			},
 //			UserExistsByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) (bool, error) {
@@ -119,16 +119,16 @@ var _ UserRepository = &UserRepositoryMock{}
 //	}
 type UserRepositoryMock struct {
 	// DeleteUserByUserNameFunc mocks the DeleteUserByUserName method.
-	DeleteUserByUserNameFunc func(ctx context.Context, db store.Queryer, userName string) error
+	DeleteUserByUserNameFunc func(ctx context.Context, db store.Execer, userName string) error
 
 	// GetUserByUserNameFunc mocks the GetUserByUserName method.
 	GetUserByUserNameFunc func(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
 
 	// RegisterUserFunc mocks the RegisterUser method.
-	RegisterUserFunc func(ctx context.Context, db store.Queryer, u *model.User) error
+	RegisterUserFunc func(ctx context.Context, db store.Execer, u *model.User) error
 
 	// UpdateUserFunc mocks the UpdateUser method.
-	UpdateUserFunc func(ctx context.Context, db store.Queryer, u *model.User) error
+	UpdateUserFunc func(ctx context.Context, db store.Execer, u *model.User) error
 
 	// UserExistsByUserNameFunc mocks the UserExistsByUserName method.
 	UserExistsByUserNameFunc func(ctx context.Context, db store.Queryer, userName string) (bool, error)
@@ -143,7 +143,7 @@ type UserRepositoryMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Db is the db argument value.
-			Db store.Queryer
+			Db store.Execer
 			// UserName is the userName argument value.
 			UserName string
 		}
@@ -161,7 +161,7 @@ type UserRepositoryMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Db is the db argument value.
-			Db store.Queryer
+			Db store.Execer
 			// U is the u argument value.
 			U *model.User
 		}
@@ -170,7 +170,7 @@ type UserRepositoryMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Db is the db argument value.
-			Db store.Queryer
+			Db store.Execer
 			// U is the u argument value.
 			U *model.User
 		}
@@ -202,13 +202,13 @@ type UserRepositoryMock struct {
 }
 
 // DeleteUserByUserName calls DeleteUserByUserNameFunc.
-func (mock *UserRepositoryMock) DeleteUserByUserName(ctx context.Context, db store.Queryer, userName string) error {
+func (mock *UserRepositoryMock) DeleteUserByUserName(ctx context.Context, db store.Execer, userName string) error {
 	if mock.DeleteUserByUserNameFunc == nil {
 		panic("UserRepositoryMock.DeleteUserByUserNameFunc: method is nil but UserRepository.DeleteUserByUserName was just called")
 	}
 	callInfo := struct {
 		Ctx      context.Context
-		Db       store.Queryer
+		Db       store.Execer
 		UserName string
 	}{
 		Ctx:      ctx,
@@ -227,12 +227,12 @@ func (mock *UserRepositoryMock) DeleteUserByUserName(ctx context.Context, db sto
 //	len(mockedUserRepository.DeleteUserByUserNameCalls())
 func (mock *UserRepositoryMock) DeleteUserByUserNameCalls() []struct {
 	Ctx      context.Context
-	Db       store.Queryer
+	Db       store.Execer
 	UserName string
 } {
 	var calls []struct {
 		Ctx      context.Context
-		Db       store.Queryer
+		Db       store.Execer
 		UserName string
 	}
 	mock.lockDeleteUserByUserName.RLock()
@@ -282,13 +282,13 @@ func (mock *UserRepositoryMock) GetUserByUserNameCalls() []struct {
 }
 
 // RegisterUser calls RegisterUserFunc.
-func (mock *UserRepositoryMock) RegisterUser(ctx context.Context, db store.Queryer, u *model.User) error {
+func (mock *UserRepositoryMock) RegisterUser(ctx context.Context, db store.Execer, u *model.User) error {
 	if mock.RegisterUserFunc == nil {
 		panic("UserRepositoryMock.RegisterUserFunc: method is nil but UserRepository.RegisterUser was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
-		Db  store.Queryer
+		Db  store.Execer
 		U   *model.User
 	}{
 		Ctx: ctx,
@@ -307,12 +307,12 @@ func (mock *UserRepositoryMock) RegisterUser(ctx context.Context, db store.Query
 //	len(mockedUserRepository.RegisterUserCalls())
 func (mock *UserRepositoryMock) RegisterUserCalls() []struct {
 	Ctx context.Context
-	Db  store.Queryer
+	Db  store.Execer
 	U   *model.User
 } {
 	var calls []struct {
 		Ctx context.Context
-		Db  store.Queryer
+		Db  store.Execer
 		U   *model.User
 	}
 	mock.lockRegisterUser.RLock()
@@ -322,13 +322,13 @@ func (mock *UserRepositoryMock) RegisterUserCalls() []struct {
 }
 
 // UpdateUser calls UpdateUserFunc.
-func (mock *UserRepositoryMock) UpdateUser(ctx context.Context, db store.Queryer, u *model.User) error {
+func (mock *UserRepositoryMock) UpdateUser(ctx context.Context, db store.Execer, u *model.User) error {
 	if mock.UpdateUserFunc == nil {
 		panic("UserRepositoryMock.UpdateUserFunc: method is nil but UserRepository.UpdateUser was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
-		Db  store.Queryer
+		Db  store.Execer
 		U   *model.User
 	}{
 		Ctx: ctx,
@@ -347,12 +347,12 @@ func (mock *UserRepositoryMock) UpdateUser(ctx context.Context, db store.Queryer
 //	len(mockedUserRepository.UpdateUserCalls())
 func (mock *UserRepositoryMock) UpdateUserCalls() []struct {
 	Ctx context.Context
-	Db  store.Queryer
+	Db  store.Execer
 	U   *model.User
 } {
 	var calls []struct {
 		Ctx context.Context
-		Db  store.Queryer
+		Db  store.Execer
 		U   *model.User
 	}
 	mock.lockUpdateUser.RLock()
@@ -451,6 +451,9 @@ var _ Auth = &AuthMock{}
 //
 //		// make and configure a mocked Auth
 //		mockedAuth := &AuthMock{
+//			ConfirmSignUpFunc: func(ctx context.Context, cognitoUserName string, code string) error {
+//				panic("mock out the ConfirmSignUp method")
+//			},
 //			SignUpFunc: func(ctx context.Context, email string, password string) (string, error) {
 //				panic("mock out the SignUp method")
 //			},
@@ -461,11 +464,23 @@ var _ Auth = &AuthMock{}
 //
 //	}
 type AuthMock struct {
+	// ConfirmSignUpFunc mocks the ConfirmSignUp method.
+	ConfirmSignUpFunc func(ctx context.Context, cognitoUserName string, code string) error
+
 	// SignUpFunc mocks the SignUp method.
 	SignUpFunc func(ctx context.Context, email string, password string) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// ConfirmSignUp holds details about calls to the ConfirmSignUp method.
+		ConfirmSignUp []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CognitoUserName is the cognitoUserName argument value.
+			CognitoUserName string
+			// Code is the code argument value.
+			Code string
+		}
 		// SignUp holds details about calls to the SignUp method.
 		SignUp []struct {
 			// Ctx is the ctx argument value.
@@ -476,7 +491,48 @@ type AuthMock struct {
 			Password string
 		}
 	}
-	lockSignUp sync.RWMutex
+	lockConfirmSignUp sync.RWMutex
+	lockSignUp        sync.RWMutex
+}
+
+// ConfirmSignUp calls ConfirmSignUpFunc.
+func (mock *AuthMock) ConfirmSignUp(ctx context.Context, cognitoUserName string, code string) error {
+	if mock.ConfirmSignUpFunc == nil {
+		panic("AuthMock.ConfirmSignUpFunc: method is nil but Auth.ConfirmSignUp was just called")
+	}
+	callInfo := struct {
+		Ctx             context.Context
+		CognitoUserName string
+		Code            string
+	}{
+		Ctx:             ctx,
+		CognitoUserName: cognitoUserName,
+		Code:            code,
+	}
+	mock.lockConfirmSignUp.Lock()
+	mock.calls.ConfirmSignUp = append(mock.calls.ConfirmSignUp, callInfo)
+	mock.lockConfirmSignUp.Unlock()
+	return mock.ConfirmSignUpFunc(ctx, cognitoUserName, code)
+}
+
+// ConfirmSignUpCalls gets all the calls that were made to ConfirmSignUp.
+// Check the length with:
+//
+//	len(mockedAuth.ConfirmSignUpCalls())
+func (mock *AuthMock) ConfirmSignUpCalls() []struct {
+	Ctx             context.Context
+	CognitoUserName string
+	Code            string
+} {
+	var calls []struct {
+		Ctx             context.Context
+		CognitoUserName string
+		Code            string
+	}
+	mock.lockConfirmSignUp.RLock()
+	calls = mock.calls.ConfirmSignUp
+	mock.lockConfirmSignUp.RUnlock()
+	return calls
 }
 
 // SignUp calls SignUpFunc.

--- a/restapi/service/store_moq_test.go
+++ b/restapi/service/store_moq_test.go
@@ -10,6 +10,472 @@ import (
 	"sync"
 )
 
+// DBConnectionMock is a mock implementation of store.DBConnection.
+//
+//	func TestSomethingThatUsesDBConnection(t *testing.T) {
+//
+//		// make and configure a mocked store.DBConnection
+//		mockedDBConnection := &DBConnectionMock{
+//			BeginTxxFunc: func(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error) {
+//				panic("mock out the BeginTxx method")
+//			},
+//			ExecContextFunc: func(ctx context.Context, query string, args ...any) (sql.Result, error) {
+//				panic("mock out the ExecContext method")
+//			},
+//			GetContextFunc: func(ctx context.Context, dest interface{}, query string, args ...any) error {
+//				panic("mock out the GetContext method")
+//			},
+//			NamedExecContextFunc: func(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+//				panic("mock out the NamedExecContext method")
+//			},
+//			PreparexContextFunc: func(ctx context.Context, query string) (*sqlx.Stmt, error) {
+//				panic("mock out the PreparexContext method")
+//			},
+//			QueryRowxContextFunc: func(ctx context.Context, query string, args ...any) *sqlx.Row {
+//				panic("mock out the QueryRowxContext method")
+//			},
+//			QueryxContextFunc: func(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
+//				panic("mock out the QueryxContext method")
+//			},
+//			SelectContextFunc: func(ctx context.Context, dest interface{}, query string, args ...any) error {
+//				panic("mock out the SelectContext method")
+//			},
+//		}
+//
+//		// use mockedDBConnection in code that requires store.DBConnection
+//		// and then make assertions.
+//
+//	}
+type DBConnectionMock struct {
+	// BeginTxxFunc mocks the BeginTxx method.
+	BeginTxxFunc func(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error)
+
+	// ExecContextFunc mocks the ExecContext method.
+	ExecContextFunc func(ctx context.Context, query string, args ...any) (sql.Result, error)
+
+	// GetContextFunc mocks the GetContext method.
+	GetContextFunc func(ctx context.Context, dest interface{}, query string, args ...any) error
+
+	// NamedExecContextFunc mocks the NamedExecContext method.
+	NamedExecContextFunc func(ctx context.Context, query string, arg interface{}) (sql.Result, error)
+
+	// PreparexContextFunc mocks the PreparexContext method.
+	PreparexContextFunc func(ctx context.Context, query string) (*sqlx.Stmt, error)
+
+	// QueryRowxContextFunc mocks the QueryRowxContext method.
+	QueryRowxContextFunc func(ctx context.Context, query string, args ...any) *sqlx.Row
+
+	// QueryxContextFunc mocks the QueryxContext method.
+	QueryxContextFunc func(ctx context.Context, query string, args ...any) (*sqlx.Rows, error)
+
+	// SelectContextFunc mocks the SelectContext method.
+	SelectContextFunc func(ctx context.Context, dest interface{}, query string, args ...any) error
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// BeginTxx holds details about calls to the BeginTxx method.
+		BeginTxx []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Opts is the opts argument value.
+			Opts *sql.TxOptions
+		}
+		// ExecContext holds details about calls to the ExecContext method.
+		ExecContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Query is the query argument value.
+			Query string
+			// Args is the args argument value.
+			Args []any
+		}
+		// GetContext holds details about calls to the GetContext method.
+		GetContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Dest is the dest argument value.
+			Dest interface{}
+			// Query is the query argument value.
+			Query string
+			// Args is the args argument value.
+			Args []any
+		}
+		// NamedExecContext holds details about calls to the NamedExecContext method.
+		NamedExecContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Query is the query argument value.
+			Query string
+			// Arg is the arg argument value.
+			Arg interface{}
+		}
+		// PreparexContext holds details about calls to the PreparexContext method.
+		PreparexContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Query is the query argument value.
+			Query string
+		}
+		// QueryRowxContext holds details about calls to the QueryRowxContext method.
+		QueryRowxContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Query is the query argument value.
+			Query string
+			// Args is the args argument value.
+			Args []any
+		}
+		// QueryxContext holds details about calls to the QueryxContext method.
+		QueryxContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Query is the query argument value.
+			Query string
+			// Args is the args argument value.
+			Args []any
+		}
+		// SelectContext holds details about calls to the SelectContext method.
+		SelectContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Dest is the dest argument value.
+			Dest interface{}
+			// Query is the query argument value.
+			Query string
+			// Args is the args argument value.
+			Args []any
+		}
+	}
+	lockBeginTxx         sync.RWMutex
+	lockExecContext      sync.RWMutex
+	lockGetContext       sync.RWMutex
+	lockNamedExecContext sync.RWMutex
+	lockPreparexContext  sync.RWMutex
+	lockQueryRowxContext sync.RWMutex
+	lockQueryxContext    sync.RWMutex
+	lockSelectContext    sync.RWMutex
+}
+
+// BeginTxx calls BeginTxxFunc.
+func (mock *DBConnectionMock) BeginTxx(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error) {
+	if mock.BeginTxxFunc == nil {
+		panic("DBConnectionMock.BeginTxxFunc: method is nil but DBConnection.BeginTxx was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		Opts *sql.TxOptions
+	}{
+		Ctx:  ctx,
+		Opts: opts,
+	}
+	mock.lockBeginTxx.Lock()
+	mock.calls.BeginTxx = append(mock.calls.BeginTxx, callInfo)
+	mock.lockBeginTxx.Unlock()
+	return mock.BeginTxxFunc(ctx, opts)
+}
+
+// BeginTxxCalls gets all the calls that were made to BeginTxx.
+// Check the length with:
+//
+//	len(mockedDBConnection.BeginTxxCalls())
+func (mock *DBConnectionMock) BeginTxxCalls() []struct {
+	Ctx  context.Context
+	Opts *sql.TxOptions
+} {
+	var calls []struct {
+		Ctx  context.Context
+		Opts *sql.TxOptions
+	}
+	mock.lockBeginTxx.RLock()
+	calls = mock.calls.BeginTxx
+	mock.lockBeginTxx.RUnlock()
+	return calls
+}
+
+// ExecContext calls ExecContextFunc.
+func (mock *DBConnectionMock) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if mock.ExecContextFunc == nil {
+		panic("DBConnectionMock.ExecContextFunc: method is nil but DBConnection.ExecContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}{
+		Ctx:   ctx,
+		Query: query,
+		Args:  args,
+	}
+	mock.lockExecContext.Lock()
+	mock.calls.ExecContext = append(mock.calls.ExecContext, callInfo)
+	mock.lockExecContext.Unlock()
+	return mock.ExecContextFunc(ctx, query, args...)
+}
+
+// ExecContextCalls gets all the calls that were made to ExecContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.ExecContextCalls())
+func (mock *DBConnectionMock) ExecContextCalls() []struct {
+	Ctx   context.Context
+	Query string
+	Args  []any
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}
+	mock.lockExecContext.RLock()
+	calls = mock.calls.ExecContext
+	mock.lockExecContext.RUnlock()
+	return calls
+}
+
+// GetContext calls GetContextFunc.
+func (mock *DBConnectionMock) GetContext(ctx context.Context, dest interface{}, query string, args ...any) error {
+	if mock.GetContextFunc == nil {
+		panic("DBConnectionMock.GetContextFunc: method is nil but DBConnection.GetContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Dest  interface{}
+		Query string
+		Args  []any
+	}{
+		Ctx:   ctx,
+		Dest:  dest,
+		Query: query,
+		Args:  args,
+	}
+	mock.lockGetContext.Lock()
+	mock.calls.GetContext = append(mock.calls.GetContext, callInfo)
+	mock.lockGetContext.Unlock()
+	return mock.GetContextFunc(ctx, dest, query, args...)
+}
+
+// GetContextCalls gets all the calls that were made to GetContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.GetContextCalls())
+func (mock *DBConnectionMock) GetContextCalls() []struct {
+	Ctx   context.Context
+	Dest  interface{}
+	Query string
+	Args  []any
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Dest  interface{}
+		Query string
+		Args  []any
+	}
+	mock.lockGetContext.RLock()
+	calls = mock.calls.GetContext
+	mock.lockGetContext.RUnlock()
+	return calls
+}
+
+// NamedExecContext calls NamedExecContextFunc.
+func (mock *DBConnectionMock) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
+	if mock.NamedExecContextFunc == nil {
+		panic("DBConnectionMock.NamedExecContextFunc: method is nil but DBConnection.NamedExecContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Query string
+		Arg   interface{}
+	}{
+		Ctx:   ctx,
+		Query: query,
+		Arg:   arg,
+	}
+	mock.lockNamedExecContext.Lock()
+	mock.calls.NamedExecContext = append(mock.calls.NamedExecContext, callInfo)
+	mock.lockNamedExecContext.Unlock()
+	return mock.NamedExecContextFunc(ctx, query, arg)
+}
+
+// NamedExecContextCalls gets all the calls that were made to NamedExecContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.NamedExecContextCalls())
+func (mock *DBConnectionMock) NamedExecContextCalls() []struct {
+	Ctx   context.Context
+	Query string
+	Arg   interface{}
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Query string
+		Arg   interface{}
+	}
+	mock.lockNamedExecContext.RLock()
+	calls = mock.calls.NamedExecContext
+	mock.lockNamedExecContext.RUnlock()
+	return calls
+}
+
+// PreparexContext calls PreparexContextFunc.
+func (mock *DBConnectionMock) PreparexContext(ctx context.Context, query string) (*sqlx.Stmt, error) {
+	if mock.PreparexContextFunc == nil {
+		panic("DBConnectionMock.PreparexContextFunc: method is nil but DBConnection.PreparexContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Query string
+	}{
+		Ctx:   ctx,
+		Query: query,
+	}
+	mock.lockPreparexContext.Lock()
+	mock.calls.PreparexContext = append(mock.calls.PreparexContext, callInfo)
+	mock.lockPreparexContext.Unlock()
+	return mock.PreparexContextFunc(ctx, query)
+}
+
+// PreparexContextCalls gets all the calls that were made to PreparexContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.PreparexContextCalls())
+func (mock *DBConnectionMock) PreparexContextCalls() []struct {
+	Ctx   context.Context
+	Query string
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Query string
+	}
+	mock.lockPreparexContext.RLock()
+	calls = mock.calls.PreparexContext
+	mock.lockPreparexContext.RUnlock()
+	return calls
+}
+
+// QueryRowxContext calls QueryRowxContextFunc.
+func (mock *DBConnectionMock) QueryRowxContext(ctx context.Context, query string, args ...any) *sqlx.Row {
+	if mock.QueryRowxContextFunc == nil {
+		panic("DBConnectionMock.QueryRowxContextFunc: method is nil but DBConnection.QueryRowxContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}{
+		Ctx:   ctx,
+		Query: query,
+		Args:  args,
+	}
+	mock.lockQueryRowxContext.Lock()
+	mock.calls.QueryRowxContext = append(mock.calls.QueryRowxContext, callInfo)
+	mock.lockQueryRowxContext.Unlock()
+	return mock.QueryRowxContextFunc(ctx, query, args...)
+}
+
+// QueryRowxContextCalls gets all the calls that were made to QueryRowxContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.QueryRowxContextCalls())
+func (mock *DBConnectionMock) QueryRowxContextCalls() []struct {
+	Ctx   context.Context
+	Query string
+	Args  []any
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}
+	mock.lockQueryRowxContext.RLock()
+	calls = mock.calls.QueryRowxContext
+	mock.lockQueryRowxContext.RUnlock()
+	return calls
+}
+
+// QueryxContext calls QueryxContextFunc.
+func (mock *DBConnectionMock) QueryxContext(ctx context.Context, query string, args ...any) (*sqlx.Rows, error) {
+	if mock.QueryxContextFunc == nil {
+		panic("DBConnectionMock.QueryxContextFunc: method is nil but DBConnection.QueryxContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}{
+		Ctx:   ctx,
+		Query: query,
+		Args:  args,
+	}
+	mock.lockQueryxContext.Lock()
+	mock.calls.QueryxContext = append(mock.calls.QueryxContext, callInfo)
+	mock.lockQueryxContext.Unlock()
+	return mock.QueryxContextFunc(ctx, query, args...)
+}
+
+// QueryxContextCalls gets all the calls that were made to QueryxContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.QueryxContextCalls())
+func (mock *DBConnectionMock) QueryxContextCalls() []struct {
+	Ctx   context.Context
+	Query string
+	Args  []any
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Query string
+		Args  []any
+	}
+	mock.lockQueryxContext.RLock()
+	calls = mock.calls.QueryxContext
+	mock.lockQueryxContext.RUnlock()
+	return calls
+}
+
+// SelectContext calls SelectContextFunc.
+func (mock *DBConnectionMock) SelectContext(ctx context.Context, dest interface{}, query string, args ...any) error {
+	if mock.SelectContextFunc == nil {
+		panic("DBConnectionMock.SelectContextFunc: method is nil but DBConnection.SelectContext was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Dest  interface{}
+		Query string
+		Args  []any
+	}{
+		Ctx:   ctx,
+		Dest:  dest,
+		Query: query,
+		Args:  args,
+	}
+	mock.lockSelectContext.Lock()
+	mock.calls.SelectContext = append(mock.calls.SelectContext, callInfo)
+	mock.lockSelectContext.Unlock()
+	return mock.SelectContextFunc(ctx, dest, query, args...)
+}
+
+// SelectContextCalls gets all the calls that were made to SelectContext.
+// Check the length with:
+//
+//	len(mockedDBConnection.SelectContextCalls())
+func (mock *DBConnectionMock) SelectContextCalls() []struct {
+	Ctx   context.Context
+	Dest  interface{}
+	Query string
+	Args  []any
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Dest  interface{}
+		Query string
+		Args  []any
+	}
+	mock.lockSelectContext.RLock()
+	calls = mock.calls.SelectContext
+	mock.lockSelectContext.RUnlock()
+	return calls
+}
+
 // BeginnerMock is a mock implementation of store.Beginner.
 //
 //	func TestSomethingThatUsesBeginner(t *testing.T) {
@@ -152,14 +618,8 @@ func (mock *PreparerMock) PreparexContextCalls() []struct {
 //
 //		// make and configure a mocked store.Queryer
 //		mockedQueryer := &QueryerMock{
-//			ExecContextFunc: func(ctx context.Context, query string, args ...any) (sql.Result, error) {
-//				panic("mock out the ExecContext method")
-//			},
 //			GetContextFunc: func(ctx context.Context, dest interface{}, query string, args ...any) error {
 //				panic("mock out the GetContext method")
-//			},
-//			NamedExecContextFunc: func(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
-//				panic("mock out the NamedExecContext method")
 //			},
 //			PreparexContextFunc: func(ctx context.Context, query string) (*sqlx.Stmt, error) {
 //				panic("mock out the PreparexContext method")
@@ -180,14 +640,8 @@ func (mock *PreparerMock) PreparexContextCalls() []struct {
 //
 //	}
 type QueryerMock struct {
-	// ExecContextFunc mocks the ExecContext method.
-	ExecContextFunc func(ctx context.Context, query string, args ...any) (sql.Result, error)
-
 	// GetContextFunc mocks the GetContext method.
 	GetContextFunc func(ctx context.Context, dest interface{}, query string, args ...any) error
-
-	// NamedExecContextFunc mocks the NamedExecContext method.
-	NamedExecContextFunc func(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 
 	// PreparexContextFunc mocks the PreparexContext method.
 	PreparexContextFunc func(ctx context.Context, query string) (*sqlx.Stmt, error)
@@ -203,15 +657,6 @@ type QueryerMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// ExecContext holds details about calls to the ExecContext method.
-		ExecContext []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Query is the query argument value.
-			Query string
-			// Args is the args argument value.
-			Args []any
-		}
 		// GetContext holds details about calls to the GetContext method.
 		GetContext []struct {
 			// Ctx is the ctx argument value.
@@ -222,15 +667,6 @@ type QueryerMock struct {
 			Query string
 			// Args is the args argument value.
 			Args []any
-		}
-		// NamedExecContext holds details about calls to the NamedExecContext method.
-		NamedExecContext []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Query is the query argument value.
-			Query string
-			// Arg is the arg argument value.
-			Arg interface{}
 		}
 		// PreparexContext holds details about calls to the PreparexContext method.
 		PreparexContext []struct {
@@ -269,53 +705,11 @@ type QueryerMock struct {
 			Args []any
 		}
 	}
-	lockExecContext      sync.RWMutex
 	lockGetContext       sync.RWMutex
-	lockNamedExecContext sync.RWMutex
 	lockPreparexContext  sync.RWMutex
 	lockQueryRowxContext sync.RWMutex
 	lockQueryxContext    sync.RWMutex
 	lockSelectContext    sync.RWMutex
-}
-
-// ExecContext calls ExecContextFunc.
-func (mock *QueryerMock) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	if mock.ExecContextFunc == nil {
-		panic("QueryerMock.ExecContextFunc: method is nil but Queryer.ExecContext was just called")
-	}
-	callInfo := struct {
-		Ctx   context.Context
-		Query string
-		Args  []any
-	}{
-		Ctx:   ctx,
-		Query: query,
-		Args:  args,
-	}
-	mock.lockExecContext.Lock()
-	mock.calls.ExecContext = append(mock.calls.ExecContext, callInfo)
-	mock.lockExecContext.Unlock()
-	return mock.ExecContextFunc(ctx, query, args...)
-}
-
-// ExecContextCalls gets all the calls that were made to ExecContext.
-// Check the length with:
-//
-//	len(mockedQueryer.ExecContextCalls())
-func (mock *QueryerMock) ExecContextCalls() []struct {
-	Ctx   context.Context
-	Query string
-	Args  []any
-} {
-	var calls []struct {
-		Ctx   context.Context
-		Query string
-		Args  []any
-	}
-	mock.lockExecContext.RLock()
-	calls = mock.calls.ExecContext
-	mock.lockExecContext.RUnlock()
-	return calls
 }
 
 // GetContext calls GetContextFunc.
@@ -359,46 +753,6 @@ func (mock *QueryerMock) GetContextCalls() []struct {
 	mock.lockGetContext.RLock()
 	calls = mock.calls.GetContext
 	mock.lockGetContext.RUnlock()
-	return calls
-}
-
-// NamedExecContext calls NamedExecContextFunc.
-func (mock *QueryerMock) NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error) {
-	if mock.NamedExecContextFunc == nil {
-		panic("QueryerMock.NamedExecContextFunc: method is nil but Queryer.NamedExecContext was just called")
-	}
-	callInfo := struct {
-		Ctx   context.Context
-		Query string
-		Arg   interface{}
-	}{
-		Ctx:   ctx,
-		Query: query,
-		Arg:   arg,
-	}
-	mock.lockNamedExecContext.Lock()
-	mock.calls.NamedExecContext = append(mock.calls.NamedExecContext, callInfo)
-	mock.lockNamedExecContext.Unlock()
-	return mock.NamedExecContextFunc(ctx, query, arg)
-}
-
-// NamedExecContextCalls gets all the calls that were made to NamedExecContext.
-// Check the length with:
-//
-//	len(mockedQueryer.NamedExecContextCalls())
-func (mock *QueryerMock) NamedExecContextCalls() []struct {
-	Ctx   context.Context
-	Query string
-	Arg   interface{}
-} {
-	var calls []struct {
-		Ctx   context.Context
-		Query string
-		Arg   interface{}
-	}
-	mock.lockNamedExecContext.RLock()
-	calls = mock.calls.NamedExecContext
-	mock.lockNamedExecContext.RUnlock()
 	return calls
 }
 

--- a/restapi/service/user.go
+++ b/restapi/service/user.go
@@ -10,31 +10,6 @@ import (
 	"github.com/kngnkg/tunetrail/restapi/store"
 )
 
-var (
-	// ユーザー名が既に存在する
-	ErrUserNameAlreadyExists = errors.New("service: user name already exists")
-	// メールアドレスが既に存在する
-	ErrEmailAlreadyExists = errors.New("service: email already exists")
-	// ユーザーが存在しない
-	ErrUserNotFound = errors.New("service: user not found")
-)
-
-type UserRepository interface {
-	// WithTransactionはトランザクションを実行する
-	WithTransaction(ctx context.Context, db store.Beginner, f func(tx *sqlx.Tx) error) error
-	// RegisterUserはユーザーを登録する
-	// RegisterUserInfo
-	RegisterUser(ctx context.Context, db store.Queryer, u *model.User) error
-	// UserExistsByUserNameはユーザー名が既に存在するかどうかを返す
-	UserExistsByUserName(ctx context.Context, db store.Queryer, userName string) (bool, error)
-	// GetUserByUserNameはユーザー名からユーザーを取得する
-	GetUserByUserName(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
-	// UpdateUserはユーザーを更新する
-	UpdateUser(ctx context.Context, db store.Queryer, u *model.User) error
-	// DeleteUserByUserNameはユーザー名からユーザーを削除する
-	DeleteUserByUserName(ctx context.Context, db store.Queryer, userName string) error
-}
-
 type UserService struct {
 	DB   store.Beginner
 	Repo UserRepository

--- a/restapi/service/user.go
+++ b/restapi/service/user.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UserService struct {
-	DB   store.Beginner
+	DB   store.DBConnection
 	Repo UserRepository
 }
 

--- a/restapi/service/user_test.go
+++ b/restapi/service/user_test.go
@@ -40,7 +40,7 @@ var (
 
 func TestUserServiceTestSuite(t *testing.T) {
 	t.Parallel()
-	moqDB := &BeginnerMock{}
+	moqDB := &DBConnectionMock{}
 	moqRepo := &UserRepositoryMock{}
 	fc := &clock.FixedClocker{}
 
@@ -104,7 +104,7 @@ func TestUserServiceTestSuite(t *testing.T) {
 	}
 
 	// ダミーユーザー1を更新する場合を想定
-	moqRepo.UpdateUserFunc = func(ctx context.Context, db store.Queryer, u *model.User) error {
+	moqRepo.UpdateUserFunc = func(ctx context.Context, db store.Execer, u *model.User) error {
 		if u.Id != DUMMY_1_USER_ID && u.Id != DUMMY_2_USER_ID {
 			return store.ErrUserNotFound
 		}
@@ -115,7 +115,7 @@ func TestUserServiceTestSuite(t *testing.T) {
 		return nil
 	}
 
-	moqRepo.DeleteUserByUserNameFunc = func(ctx context.Context, db store.Queryer, userName string) error {
+	moqRepo.DeleteUserByUserNameFunc = func(ctx context.Context, db store.Execer, userName string) error {
 		if userName == DUMMY_1_USERNAME || userName == DUMMY_2_USERNAME {
 			return nil
 		}

--- a/restapi/store/errors.go
+++ b/restapi/store/errors.go
@@ -1,0 +1,27 @@
+package store
+
+import "errors"
+
+// Postgresのエラーコード
+const (
+	// 重複エラーコード
+	ErrCodePostgresDuplicate = "23505"
+)
+
+// storeパッケージで用いるエラー
+var (
+	// DBとの疎通が取れない
+	ErrCannotCommunicateWithDB = errors.New("store: cannot communicate with db")
+	// トランザクション開始に失敗
+	ErrBeginTxFailed = errors.New("store: begin tx failed")
+	// ロールバックに失敗
+	ErrRollbackFailed = errors.New("store: rollback failed")
+	// コミットに失敗
+	ErrCommitFailed = errors.New("store: commit failed")
+	// ユーザーが見つからない
+	ErrUserNotFound = errors.New("store: user not found")
+	// ユーザー名が既に存在する
+	ErrUserNameAlreadyExists = errors.New("store: user name already exists")
+	// メールアドレスが既に存在する
+	ErrEmailAlreadyExists = errors.New("store: email already exists")
+)


### PR DESCRIPTION
## 変更点

- パスワードを検証する`ConfirmSignup`関数を追加
- `*sqlx.DB`をラップする`DBConnection`インタフェースを追加
- 参照系クエリを実行する`Queryer`インタフェースを追加
- 更新系クエリを実行する`Execer`インタフェースを追加
- 上記のインタフェースの変更に伴い、`store`パッケージの関数のシグニチャを修正