### PR TITLE
メール認証サービスを追加

### DIFF
--- a/restapi/handler/testdata/user/get_by_username/ok_response.json.golden
+++ b/restapi/handler/testdata/user/get_by_username/ok_response.json.golden
@@ -4,6 +4,8 @@
     "name": "dummy",
     "iconUrl": "https://example.com/icon.png",
     "bio": "dummy",
+    "password": "",
+    "email": "",
     "createdAt": "2022-05-10T12:34:56Z",
     "updatedAt": "2022-05-10T12:34:56Z"
 }

--- a/restapi/model/user.go
+++ b/restapi/model/user.go
@@ -10,11 +10,11 @@ type User struct {
 	Name      string    `json:"name" db:"name" binding:"required,min=3,max=20"`
 	IconUrl   string    `json:"iconUrl" db:"icon_url" binding:"required,url"`
 	Bio       string    `json:"bio" db:"bio" binding:"required,max=1000"`
+	Password  string    `json:"password" binding:"password"`
+	Email     string    `json:"email" binding:"email"`
 	CreatedAt time.Time `json:"createdAt" db:"created_at"`
 	UpdatedAt time.Time `json:"updatedAt" db:"updated_at"`
 }
-
-type Users []User
 
 type UserRegistrationData struct {
 	UserName string `json:"userName" binding:"required,min=3,max=20"`

--- a/restapi/service/auth_test.go
+++ b/restapi/service/auth_test.go
@@ -2,11 +2,12 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/kngnkg/tunetrail/restapi/auth"
 	"github.com/kngnkg/tunetrail/restapi/clock"
@@ -15,6 +16,12 @@ import (
 	"github.com/kngnkg/tunetrail/restapi/testutil/fixture"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+)
+
+var (
+	invalidPassword = "invalidPassword"
+	mismatchCode    = "mismatch"
+	expiredCode     = "expired"
 )
 
 type AuthServiceTestSuite struct {
@@ -26,93 +33,27 @@ type AuthServiceTestSuite struct {
 
 func TestAuthServiceTestSuite(t *testing.T) {
 	t.Parallel()
-	moqDB := &DBConnectionMock{}
-	moqRepo := &UserRepositoryMock{}
-	moqAuth := &AuthMock{}
+	suite.Run(t, new(AuthServiceTestSuite))
+}
+
+func (s *AuthServiceTestSuite) SetupTest() {
 	fc := &clock.FixedClocker{}
 
 	// テスト用のダミーユーザーを作成
 	// これらのユーザーだけがDBに存在することを想定している
-	dummyUsers := []*model.User{
-		fixture.User(&model.User{
-			Id:       DUMMY_1_USER_ID,
-			UserName: DUMMY_1_USERNAME,
-			Name:     "dummy1",
-			IconUrl:  "https://example.com/icon.png",
-			Bio:      "dummy1",
-			// タイムスタンプを固定する
-			CreatedAt: fc.Now(),
-			UpdatedAt: fc.Now(),
-		}),
-		fixture.User(&model.User{
-			Id:       DUMMY_2_USER_ID,
-			UserName: DUMMY_2_USERNAME,
-			Name:     "dummy2",
-			IconUrl:  "https://example.com/icon.png",
-			Bio:      "dummy2",
-			// タイムスタンプを固定する
-			CreatedAt: fc.Now(),
-			UpdatedAt: fc.Now(),
-		}),
-	}
+	dummyUsers := fixture.CreateUsers(2)
 
-	// 各種モック関数の設定
-	moqDB.BeginTxxFunc = func(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error) {
-		return &sqlx.Tx{}, nil
-	}
+	moqRepo := s.setupRepoMock()
+	moqAuth := s.setupAuthMock()
 
-	moqRepo.WithTransactionFunc = func(ctx context.Context, db store.Beginner, fn func(tx *sqlx.Tx) error) error {
-		tx, err := db.BeginTxx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		err = fn(tx)
-		if err != nil {
-			return fmt.Errorf("failed to execute mock transaction: %w", err)
-		}
-		return nil
+	s.as = &AuthService{
+		DB:   &DBConnectionMock{},
+		Repo: moqRepo,
+		Auth: moqAuth,
 	}
-
-	moqRepo.RegisterUserFunc = func(ctx context.Context, db store.Execer, u *model.User) error {
-		// ダミーの値を設定
-		u.Id = "1"
-		u.CreatedAt = fc.Now()
-		u.UpdatedAt = fc.Now()
-		return nil
-	}
-
-	moqRepo.UserExistsByUserNameFunc = func(ctx context.Context, db store.Queryer, userName string) (bool, error) {
-		if userName == DUMMY_1_USERNAME || userName == DUMMY_2_USERNAME {
-			return true, nil
-		}
-		return false, nil
-	}
-
-	moqAuth.SignUpFunc = func(ctx context.Context, email, password string) (string, error) {
-		if password != VALID_PASSWORD {
-			return "", auth.ErrInvalidPassword
-		}
-		if password == DUMMY_1_PASSWORD || password == DUMMY_2_PASSWORD {
-			return "", auth.ErrInvalidPassword
-		}
-		if email == DUMMY_1_EMAIL || email == DUMMY_2_EMAIL {
-			return "", auth.ErrEmailAlreadyExists
-		}
-		return VALID_USER_ID, nil
-	}
-
-	suite.Run(t, &AuthServiceTestSuite{
-		as: &AuthService{
-			DB:   moqDB,
-			Repo: moqRepo,
-			Auth: moqAuth,
-		},
-		fc:         fc,
-		dummyUsers: dummyUsers,
-	})
+	s.fc = fc
+	s.dummyUsers = dummyUsers
 }
-
-func (s *AuthServiceTestSuite) SetupTest() {}
 
 func (s *AuthServiceTestSuite) TestRegisterUser() {
 	type args struct {
@@ -133,12 +74,11 @@ func (s *AuthServiceTestSuite) TestRegisterUser() {
 				data: &model.UserRegistrationData{
 					UserName: "test",
 					Name:     "test",
-					Password: VALID_PASSWORD,
+					Password: "test",
 					Email:    "test@example.com",
 				},
 			},
 			&model.User{
-				Id:        VALID_USER_ID,
 				UserName:  "test",
 				Name:      "test",
 				IconUrl:   "",
@@ -154,9 +94,9 @@ func (s *AuthServiceTestSuite) TestRegisterUser() {
 			args{
 				ctx: context.Background(),
 				data: &model.UserRegistrationData{
-					UserName: DUMMY_1_USERNAME, // ダミーユーザーのユーザー名と重複させる
+					UserName: s.dummyUsers[0].UserName, // ダミーユーザーのユーザー名と重複させる
 					Name:     "test",
-					Password: VALID_PASSWORD,
+					Password: "test",
 					Email:    "test@example.com",
 				},
 			},
@@ -171,8 +111,8 @@ func (s *AuthServiceTestSuite) TestRegisterUser() {
 				data: &model.UserRegistrationData{
 					UserName: "test",
 					Name:     "test",
-					Password: VALID_PASSWORD,
-					Email:    DUMMY_1_EMAIL, // ダミーユーザーのメールアドレスと重複させる
+					Password: "test",
+					Email:    s.dummyUsers[0].Email, // ダミーユーザーのメールアドレスと重複させる
 				},
 			},
 			nil,
@@ -187,9 +127,146 @@ func (s *AuthServiceTestSuite) TestRegisterUser() {
 			if !errors.Is(err, tt.wantErr) {
 				s.T().Errorf("UserService.RegisterUser() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil {
-				assert.Equal(s.T(), tt.wantUser, got)
+
+			if tt.wantErr != nil {
+				// 異常系のテストの場合はここで終了
+				return
+			}
+
+			// idが設定されていることを確認
+			assert.NotEmpty(s.T(), got.Id)
+
+			// それ以外のフィールドは正しい値が設定されていることを確認
+			wantv := reflect.ValueOf(tt.wantUser).Elem()
+			gotv := reflect.ValueOf(got).Elem()
+			for i := 0; i < wantv.NumField(); i++ {
+				if field := wantv.Type().Field(i); field.Name == "Id" {
+					continue
+				}
+				assert.Equal(s.T(), wantv.Field(i).Interface(), gotv.Field(i).Interface())
 			}
 		})
 	}
+}
+
+func (s *AuthServiceTestSuite) TestConfirmEmail() {
+	type args struct {
+		ctx      context.Context
+		userName string
+		code     string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			"success",
+			args{
+				ctx:      context.Background(),
+				userName: s.dummyUsers[0].UserName,
+				code:     "test",
+			},
+			nil,
+		},
+		{
+			"user not found",
+			args{
+				ctx:      context.Background(),
+				userName: "not_found",
+				code:     "test",
+			},
+			ErrUserNotFound,
+		},
+		{
+			"code mismatch",
+			args{
+				ctx:      context.Background(),
+				userName: s.dummyUsers[0].UserName,
+				code:     mismatchCode,
+			},
+			auth.ErrCodeMismatch,
+		},
+		{
+			"code expired",
+			args{
+				ctx:      context.Background(),
+				userName: s.dummyUsers[0].UserName,
+				code:     expiredCode,
+			},
+			auth.ErrCodeExpired,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := s.as.ConfirmEmail(tt.args.ctx, tt.args.userName, tt.args.code)
+			if !errors.Is(err, tt.wantErr) {
+				s.T().Errorf("UserService.ConfirmEmail() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func (s *AuthServiceTestSuite) setupRepoMock() *UserRepositoryMock {
+	mock := &UserRepositoryMock{
+		WithTransactionFunc: func(ctx context.Context, db store.Beginner, fn func(tx *sqlx.Tx) error) error {
+			tx := &sqlx.Tx{}
+			err := fn(tx)
+			if err != nil {
+				return fmt.Errorf("failed to execute mock transaction: %w", err)
+			}
+			return nil
+		},
+		GetUserByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) (*model.User, error) {
+			for _, u := range s.dummyUsers {
+				if userName == u.UserName {
+					return u, nil
+				}
+			}
+			return nil, store.ErrUserNotFound
+		},
+		UserExistsByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) (bool, error) {
+			for _, u := range s.dummyUsers {
+				if userName == u.UserName {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+		RegisterUserFunc: func(ctx context.Context, db store.Execer, u *model.User) error {
+			// ダミーの値を設定
+			u.CreatedAt = s.fc.Now()
+			u.UpdatedAt = s.fc.Now()
+			return nil
+		},
+	}
+	return mock
+}
+
+func (s *AuthServiceTestSuite) setupAuthMock() *AuthMock {
+	mock := &AuthMock{
+		SignUpFunc: func(ctx context.Context, email, password string) (string, error) {
+			if password == invalidPassword {
+				return "", auth.ErrInvalidPassword
+			}
+			for _, u := range s.dummyUsers {
+				if email == u.Email {
+					return "", auth.ErrEmailAlreadyExists
+				}
+			}
+			return uuid.New().String(), nil
+		},
+		ConfirmSignUpFunc: func(ctx context.Context, userId, code string) error {
+			if code == mismatchCode {
+				return auth.ErrCodeMismatch
+			}
+			if code == expiredCode {
+				return auth.ErrCodeExpired
+			}
+			return nil
+		},
+	}
+	return mock
 }

--- a/restapi/service/interfaces.go
+++ b/restapi/service/interfaces.go
@@ -10,7 +10,7 @@ import (
 
 type Auth interface {
 	SignUp(ctx context.Context, email, password string) (string, error)
-	ConfirmSignUp(ctx context.Context, cognitoUserName, code string) error
+	ConfirmSignUp(ctx context.Context, userId, code string) error
 }
 
 type UserRepository interface {

--- a/restapi/service/moq_test.go
+++ b/restapi/service/moq_test.go
@@ -451,7 +451,7 @@ var _ Auth = &AuthMock{}
 //
 //		// make and configure a mocked Auth
 //		mockedAuth := &AuthMock{
-//			ConfirmSignUpFunc: func(ctx context.Context, cognitoUserName string, code string) error {
+//			ConfirmSignUpFunc: func(ctx context.Context, userId string, code string) error {
 //				panic("mock out the ConfirmSignUp method")
 //			},
 //			SignUpFunc: func(ctx context.Context, email string, password string) (string, error) {
@@ -465,7 +465,7 @@ var _ Auth = &AuthMock{}
 //	}
 type AuthMock struct {
 	// ConfirmSignUpFunc mocks the ConfirmSignUp method.
-	ConfirmSignUpFunc func(ctx context.Context, cognitoUserName string, code string) error
+	ConfirmSignUpFunc func(ctx context.Context, userId string, code string) error
 
 	// SignUpFunc mocks the SignUp method.
 	SignUpFunc func(ctx context.Context, email string, password string) (string, error)
@@ -476,8 +476,8 @@ type AuthMock struct {
 		ConfirmSignUp []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// CognitoUserName is the cognitoUserName argument value.
-			CognitoUserName string
+			// UserId is the userId argument value.
+			UserId string
 			// Code is the code argument value.
 			Code string
 		}
@@ -496,23 +496,23 @@ type AuthMock struct {
 }
 
 // ConfirmSignUp calls ConfirmSignUpFunc.
-func (mock *AuthMock) ConfirmSignUp(ctx context.Context, cognitoUserName string, code string) error {
+func (mock *AuthMock) ConfirmSignUp(ctx context.Context, userId string, code string) error {
 	if mock.ConfirmSignUpFunc == nil {
 		panic("AuthMock.ConfirmSignUpFunc: method is nil but Auth.ConfirmSignUp was just called")
 	}
 	callInfo := struct {
-		Ctx             context.Context
-		CognitoUserName string
-		Code            string
+		Ctx    context.Context
+		UserId string
+		Code   string
 	}{
-		Ctx:             ctx,
-		CognitoUserName: cognitoUserName,
-		Code:            code,
+		Ctx:    ctx,
+		UserId: userId,
+		Code:   code,
 	}
 	mock.lockConfirmSignUp.Lock()
 	mock.calls.ConfirmSignUp = append(mock.calls.ConfirmSignUp, callInfo)
 	mock.lockConfirmSignUp.Unlock()
-	return mock.ConfirmSignUpFunc(ctx, cognitoUserName, code)
+	return mock.ConfirmSignUpFunc(ctx, userId, code)
 }
 
 // ConfirmSignUpCalls gets all the calls that were made to ConfirmSignUp.
@@ -520,14 +520,14 @@ func (mock *AuthMock) ConfirmSignUp(ctx context.Context, cognitoUserName string,
 //
 //	len(mockedAuth.ConfirmSignUpCalls())
 func (mock *AuthMock) ConfirmSignUpCalls() []struct {
-	Ctx             context.Context
-	CognitoUserName string
-	Code            string
+	Ctx    context.Context
+	UserId string
+	Code   string
 } {
 	var calls []struct {
-		Ctx             context.Context
-		CognitoUserName string
-		Code            string
+		Ctx    context.Context
+		UserId string
+		Code   string
 	}
 	mock.lockConfirmSignUp.RLock()
 	calls = mock.calls.ConfirmSignUp

--- a/restapi/service/user_test.go
+++ b/restapi/service/user_test.go
@@ -24,7 +24,6 @@ type UserServiceTestSuite struct {
 }
 
 var (
-	VALID_USER_ID  = "1"
 	VALID_PASSWORD = "password"
 
 	DUMMY_1_USER_ID  = "dummy1id"

--- a/restapi/store/user_test.go
+++ b/restapi/store/user_test.go
@@ -102,14 +102,18 @@ func (s *UserStoreTestSuite) TestRegisterUser() {
 			if !errors.Is(err, tt.wantErr) {
 				s.T().Errorf("Repository.RegisterUser() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.wantErr == nil {
-				// ユーザーが登録されているか確認する
-				got, err := s.r.GetUserByUserName(s.ctx, tx, tt.user.Name)
-				if err != nil {
-					s.T().Fatal(err)
-				}
-				assert.Equal(s.T(), tt.user, got)
+
+			if tt.wantErr != nil {
+				// 異常系の場合はここでテストを終了する
+				return
 			}
+
+			// ユーザーが登録されているか確認する
+			got, err := s.r.GetUserByUserName(s.ctx, tx, tt.user.Name)
+			if err != nil {
+				s.T().Fatal(err)
+			}
+			testutil.AssertUser(s.T(), tt.user, got)
 		})
 	}
 }
@@ -183,7 +187,7 @@ func (s *UserStoreTestSuite) TestGetUserByUserName() {
 			if !errors.Is(err, tt.wantErr) {
 				s.T().Errorf("Repository.GetUserByUserName() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			assert.Equal(s.T(), tt.want, got)
+			testutil.AssertUser(s.T(), tt.want, got)
 		})
 	}
 }

--- a/restapi/testutil/fixture/user.go
+++ b/restapi/testutil/fixture/user.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kngnkg/tunetrail/restapi/clock"
 	"github.com/kngnkg/tunetrail/restapi/model"
 )
 
@@ -18,6 +19,8 @@ func User(u *model.User) *model.User {
 		Name:      "test" + random,
 		IconUrl:   "test" + random,
 		Bio:       "test" + random,
+		Email:     "test" + random + "@example.com",
+		Password:  "test" + random,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -42,6 +45,12 @@ func User(u *model.User) *model.User {
 	if u.Bio != "" {
 		result.Bio = u.Bio
 	}
+	if u.Email != "" {
+		result.Email = u.Email
+	}
+	if u.Password != "" {
+		result.Password = u.Password
+	}
 	if !u.CreatedAt.IsZero() {
 		result.CreatedAt = u.CreatedAt
 	}
@@ -49,4 +58,18 @@ func User(u *model.User) *model.User {
 		result.UpdatedAt = u.UpdatedAt
 	}
 	return result
+}
+
+func CreateUsers(n int) []*model.User {
+	fc := &clock.FixedClocker{}
+
+	users := make([]*model.User, n)
+	for i := 0; i < n; i++ {
+		users[i] = User(&model.User{
+			// タイムスタンプを固定する
+			CreatedAt: fc.Now(),
+			UpdatedAt: fc.Now(),
+		})
+	}
+	return users
 }

--- a/restapi/testutil/handler.go
+++ b/restapi/testutil/handler.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func SetGinTestMode(t *testing.T) {
+	t.Helper()
+	if gin.Mode() != gin.TestMode {
+		gin.SetMode(gin.TestMode)
+	}
+}
+
 // テスト用のサーバーを起動し、URLを返す。
 // t: テスト
 // reqMethod: 登録したいリクエストメソッド
@@ -21,7 +28,7 @@ import (
 // handler: 検証したいハンドラ
 func RunTestServer(t *testing.T, reqMethod string, endpoint string, handler gin.HandlerFunc) string {
 	t.Helper()
-	router := gin.Default()
+	router := gin.New()
 
 	// ハンドラの登録
 	switch reqMethod {

--- a/restapi/testutil/store.go
+++ b/restapi/testutil/store.go
@@ -5,9 +5,12 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"reflect"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/kngnkg/tunetrail/restapi/model"
+	"github.com/stretchr/testify/assert"
 )
 
 // OpenDbForTestはテスト用のDBオブジェクトを返す。
@@ -39,5 +42,25 @@ func DeleteUserAll(t *testing.T, ctx context.Context, tx *sqlx.Tx) {
 
 	if _, err := tx.ExecContext(ctx, "DELETE FROM users"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// Password、Email以外のフィールドが一致することを確認する。
+func AssertUser(t *testing.T, expected, actial *model.User) {
+	t.Helper()
+
+	if expected == nil {
+		assert.Nil(t, actial)
+		return
+	}
+
+	ev := reflect.ValueOf(expected).Elem()
+	av := reflect.ValueOf(actial).Elem()
+	for i := 0; i < ev.NumField(); i++ {
+		field := ev.Type().Field(i)
+		if field.Name == "Password" || field.Name == "Email" {
+			continue
+		}
+		assert.Equal(t, ev.Field(i).Interface(), av.Field(i).Interface())
 	}
 }


### PR DESCRIPTION
## 変更点

- メール認証用のサービス`ConfirmEmail`を追加
- `User`構造体にフィールド`Password`、`Email`を追加
- テストのリファクタリング