### PR TITLE
メールアドレス認証コード送信ページを作成

### DIFF
--- a/webapp/app/(auth)/confirm/page.tsx
+++ b/webapp/app/(auth)/confirm/page.tsx
@@ -1,0 +1,10 @@
+import { ConfirmSignupForm } from "@/components/containers/ConfirmSignupForm/ConfirmSignupForm"
+
+// メールアドレス認証コード入力画面
+export default function ConfirmPage() {
+  return (
+    <div className="container mx-auto p-8">
+      <ConfirmSignupForm />
+    </div>
+  )
+}

--- a/webapp/app/(auth)/signin/page.tsx
+++ b/webapp/app/(auth)/signin/page.tsx
@@ -1,11 +1,18 @@
+import Link from "next/link"
+
 import { SigninForm } from "@/components/containers/SigninForm/SigninForm"
 
-// ログインページ
-export default function LoginPage() {
+// サインインページ
+export default function SigninPage() {
   return (
     <div className="container mx-auto p-8">
-      <h1 className="text-3xl mb-8">Login Page</h1>
       <SigninForm />
+      <div className="p-8">
+        アカウントをお持ちでないですか？
+        <Link href="/signup" className="text-primary">
+          登録する
+        </Link>
+      </div>
     </div>
   )
 }

--- a/webapp/app/(auth)/signup/page.tsx
+++ b/webapp/app/(auth)/signup/page.tsx
@@ -1,11 +1,18 @@
+import Link from "next/link"
+
 import { SignupForm } from "@/components/containers/SignupForm/SignupForm"
 
 // ユーザー登録ページ
 export default function SignupPage() {
   return (
     <div className="container mx-auto p-8">
-      <h1 className="text-3xl mb-8">Signup Page</h1>
       <SignupForm />
+      <div className="p-8">
+        アカウントをお持ちですか？
+        <Link href="/signin" className="text-primary">
+          サインイン
+        </Link>
+      </div>
     </div>
   )
 }

--- a/webapp/components/containers/ConfirmSignupForm/ConfirmSignupForm.tsx
+++ b/webapp/components/containers/ConfirmSignupForm/ConfirmSignupForm.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import * as React from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import {
+  confirmSignup,
+  isConfirmSignupData,
+} from "@/services/auth/confirmSignup"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import * as z from "zod"
+
+import { env } from "@/env.mjs"
+import { mergeClasses } from "@/lib/utils"
+import { confirmSignupSchema } from "@/lib/validations/auth.schema"
+import { useToast } from "@/hooks/toast/use-toast"
+import { Button } from "@/components/ui/Button/Button"
+import { Input } from "@/components/ui/Input/Input"
+
+export interface ConfirmSignupFormProps
+  extends React.HTMLAttributes<HTMLDivElement> {}
+
+type FormData = z.infer<typeof confirmSignupSchema>
+
+export const ConfirmSignupForm: React.FC<ConfirmSignupFormProps> = ({
+  className,
+  ...props
+}) => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const { register, handleSubmit, formState } = useForm<FormData>({
+    resolver: zodResolver(confirmSignupSchema),
+  })
+  const [isLoading, setIsLoading] = React.useState<boolean>(false)
+  const { showToast } = useToast()
+
+  // 登録ボタン押下時の処理
+  const onSubmit = async (data: FormData) => {
+    setIsLoading(true)
+
+    // userNameをクエリパラメータから取得
+    const userName = searchParams.get("userName")
+    if (!userName || !isConfirmSignupData({ userName, ...data })) {
+      console.log("userName: ", userName)
+      setIsLoading(false)
+      return
+    }
+
+    const error = await confirmSignup(env.NEXT_PUBLIC_API_ROOT, {
+      userName: userName,
+      code: data.code,
+    })
+    if (error) {
+      showToast({
+        intent: "error",
+        description: error,
+      })
+      setIsLoading(false)
+      return
+    }
+
+    // サインインページに遷移する
+    router.push("/signin")
+
+    setIsLoading(false)
+  }
+
+  return (
+    <div className={mergeClasses("grid gap-6", className)} {...props}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="grid gap-2">
+          <div className="grid gap-1">
+            <Input
+              id="code"
+              type="code"
+              placeholderText="認証コード"
+              disabled={isLoading}
+              {...register("code")}
+            />
+            {formState.errors.code && (
+              <p className="px-1 text-xs text-red-500">
+                {formState.errors.code.message}
+              </p>
+            )}
+          </div>
+          <div className="grid gap-1">
+            <Button type="submit" disabled={isLoading}>
+              コードを送信
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/webapp/components/containers/SignupForm/SignupForm.test.tsx
+++ b/webapp/components/containers/SignupForm/SignupForm.test.tsx
@@ -19,6 +19,10 @@ jest.mock("../../../hooks/toast/use-toast", () => ({
   useToast: jest.fn(),
 }))
 
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}))
+
 describe("SignupForm", () => {
   let mockHandleSubmit: jest.Mock
   let mockRegister: jest.Mock

--- a/webapp/components/containers/SignupForm/SignupForm.tsx
+++ b/webapp/components/containers/SignupForm/SignupForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { useRouter } from "next/navigation"
 import { isSignupData, signup } from "@/services/auth/signup"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
@@ -22,6 +23,8 @@ export const SignupForm: React.FC<SignupFormProps> = ({
   className,
   ...props
 }) => {
+  const router = useRouter()
+
   const { register, handleSubmit, formState } = useForm<FormData>({
     resolver: zodResolver(userAuthSchema),
   })
@@ -56,6 +59,10 @@ export const SignupForm: React.FC<SignupFormProps> = ({
       intent: "success",
       description: MESSAGE.SUCCESS_SIGNUP,
     })
+
+    // メールアドレス認証コード送信画面に遷移する
+    router.push("/confirm?userName=" + data.userName)
+
     setIsLoading(false)
   }
 

--- a/webapp/config/messages.ts
+++ b/webapp/config/messages.ts
@@ -13,7 +13,5 @@ export const MESSAGE = {
   },
   SUCCESS_SIGNUP: "登録に成功しました!",
   SUCCESS_LOGIN: "ログインしました!",
-  DUP_USERNAME: "ユーザー名が既に登録されています。",
-  DUP_EMAIL: "メールアドレスが既に登録されています。",
   UNKNOWN_ERROR: "不明なエラーが発生しました",
 }

--- a/webapp/lib/validations/auth.schema.ts
+++ b/webapp/lib/validations/auth.schema.ts
@@ -38,3 +38,11 @@ export const userAuthSchema = z
   .refine((data) => passwordConfirmationSchema.safeParse(data).success, {
     message: "パスワードと確認用パスワードが一致しません",
   })
+
+export const confirmSignupSchema = z.object({
+  code: z
+    .string()
+    .min(6, "確認コードは6文字です")
+    .max(6, "確認コードは6文字です")
+    .regex(/^\d+$/, "確認コードは数字のみです"),
+})

--- a/webapp/services/auth/confirmSignup.test.ts
+++ b/webapp/services/auth/confirmSignup.test.ts
@@ -1,0 +1,57 @@
+import { env } from "@/env.mjs"
+import { ApiError } from "@/types/error"
+
+import { ConfirmSignupData, confirmSignup } from "./confirmSignup"
+
+describe("confirmSignup", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test("ステータスコードが200の場合、nullを返す", async () => {
+    const body: ConfirmSignupData = {
+      userName: "test",
+      code: "test",
+    }
+
+    const mock = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+      })
+    global.fetch = jest.fn().mockImplementation(mock)
+
+    const data: ConfirmSignupData = {
+      userName: "test",
+      code: "012345",
+    }
+
+    const result = await confirmSignup(env.NEXT_PUBLIC_API_ROOT, data)
+    expect(result).toBeNull()
+  })
+
+  test("APIからエラーが返ってきた場合、エラーメッセージを返す", async () => {
+    const body: ApiError = {
+      code: 4101,
+      developerMessage: "Invalid confirmation code",
+      userMessage: "確認コードが一致しません。",
+    }
+
+    const mock = () =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(body),
+      })
+    global.fetch = jest.fn().mockImplementation(mock)
+
+    const data: ConfirmSignupData = {
+      userName: "test",
+      code: "543210",
+    }
+
+    const result = await confirmSignup(env.NEXT_PUBLIC_API_ROOT, data)
+    expect(result).toBe(body.userMessage)
+  })
+})

--- a/webapp/services/auth/confirmSignup.ts
+++ b/webapp/services/auth/confirmSignup.ts
@@ -1,0 +1,47 @@
+import { FetchError, isApiError } from "@/types/error"
+import { MESSAGE } from "@/config/messages"
+
+export interface ConfirmSignupData {
+  userName: string
+  code: string
+}
+export const isConfirmSignupData = (arg: any): arg is ConfirmSignupData => {
+  return arg.userName !== undefined && arg.code !== undefined
+}
+
+export const confirmSignup = async (
+  apiRoot: string,
+  data: ConfirmSignupData
+): Promise<null | FetchError> => {
+  try {
+    const response = await fetch(`${apiRoot}/auth/confirm`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    })
+
+    if (!response.ok) {
+      const errorResponse = await response.json()
+      if (!isApiError(errorResponse)) {
+        const error = new Error(
+          errorResponse.message ??
+            `Failed to fetch data from the API. Status: ${response.status}`
+        )
+        console.error(error)
+        throw error
+      }
+
+      return errorResponse.userMessage
+    }
+    return null
+  } catch (e) {
+    console.error(e)
+    if (e instanceof Error) {
+      return e.message
+    }
+
+    return MESSAGE.UNKNOWN_ERROR
+  }
+}

--- a/webapp/services/auth/signup.test.ts
+++ b/webapp/services/auth/signup.test.ts
@@ -1,18 +1,15 @@
-import { MESSAGE } from "@/config/messages"
+import { env } from "@/env.mjs"
+import { ApiError } from "@/types/error"
 
-import { signup } from "./signup"
+import { SignupData, signup } from "./signup"
 
 describe("signup", () => {
-  const apiRoot = "ttp://localhost:3000"
-
   beforeEach(() => {
     jest.resetAllMocks()
   })
 
-  //   test("リクエストのフォーマットが正しいこと", () => {})
-
   test("ステータスコードが200の場合、nullを返す", async () => {
-    const body = {
+    const body: SignupData = {
       userName: "test",
       name: "test",
       password: "test",
@@ -27,79 +24,40 @@ describe("signup", () => {
       })
     global.fetch = jest.fn().mockImplementation(mock)
 
-    const data = {
+    const data: SignupData = {
       userName: "test",
       name: "test",
       password: "test",
       email: "test",
     }
 
-    const result = await signup(apiRoot, data)
+    const result = await signup(env.NEXT_PUBLIC_API_ROOT, data)
     expect(result).toBeNull()
   })
 
-  describe("ステータスコードが400の場合", () => {
-    test("ユーザーネームが重複していた場合", async () => {
-      const mock = () =>
-        Promise.resolve({
-          ok: false,
-          status: 400,
-          json: () =>
-            Promise.resolve({ msg: "ユーザー名が既に登録されています。" }),
-        })
-      global.fetch = jest.fn().mockImplementation(mock)
+  test("APIからエラーが返ってきた場合、エラーメッセージを返す", async () => {
+    const body: ApiError = {
+      code: 4202,
+      developerMessage: "UserName already entry",
+      userMessage: "ユーザー名が既に存在します。",
+    }
 
-      const data = {
-        userName: "test",
-        name: "test",
-        password: "test",
-        email: "test",
-      }
-
-      const result = await signup(apiRoot, data)
-      expect(result).toBe(MESSAGE.DUP_USERNAME)
-    })
-
-    test("メールアドレスが重複していた場合", async () => {
-      const mock = () =>
-        Promise.resolve({
-          ok: false,
-          status: 400,
-          json: () =>
-            Promise.resolve({ msg: "メールアドレスが既に登録されています。" }),
-        })
-      global.fetch = jest.fn().mockImplementation(mock)
-
-      const data = {
-        userName: "test",
-        name: "test",
-        password: "test",
-        email: "test",
-      }
-
-      const result = await signup(apiRoot, data)
-      expect(result).toBe(MESSAGE.DUP_EMAIL)
-    })
-  })
-
-  test("ステータスコードが500の場合", async () => {
     const mock = () =>
       Promise.resolve({
         ok: false,
-        status: 500,
-        json: () =>
-          Promise.resolve({ msg: "サーバー内部でエラーが発生しました。" }),
+        status: 409,
+        json: () => Promise.resolve(body),
       })
     global.fetch = jest.fn().mockImplementation(mock)
 
-    const data = {
+    const data: SignupData = {
       userName: "test",
       name: "test",
       password: "test",
       email: "test",
     }
 
-    const result = await signup(apiRoot, data)
-    expect(result).toBe(MESSAGE.UNKNOWN_ERROR)
+    const result = await signup(env.NEXT_PUBLIC_API_ROOT, data)
+    expect(result).toBe(body.userMessage)
   })
 })

--- a/webapp/services/auth/signup.ts
+++ b/webapp/services/auth/signup.ts
@@ -27,7 +27,7 @@ export const signup = async (
   data: SignupData
 ): Promise<null | FetchError> => {
   try {
-    const response = await fetch(`${apiRoot}/user/register`, {
+    const response = await fetch(`${apiRoot}/auth/register`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -37,7 +37,6 @@ export const signup = async (
 
     if (!response.ok) {
       const errorResponse = await response.json()
-      console.error(errorResponse)
       if (!isApiError(errorResponse)) {
         const error = new Error(
           errorResponse.message ??
@@ -47,24 +46,19 @@ export const signup = async (
         throw error
       }
 
-      switch (response.status) {
-        case 400:
-          let errorMsg = MESSAGE.UNKNOWN_ERROR
-          if (errorResponse.msg === "ユーザー名が既に登録されています。") {
-            errorMsg = MESSAGE.DUP_USERNAME
-          }
-          if (errorResponse.msg === "メールアドレスが既に登録されています。") {
-            errorMsg = MESSAGE.DUP_EMAIL
-          }
+      // switch (response.status) {
+      //   case 400:
+      //     return errorResponse.userMessage
+      //   case 409:
+      //     return errorResponse.userMessage
+      //   case 500:
+      //     return errorResponse.userMessage
+      //   default:
+      //     return MESSAGE.UNKNOWN_ERROR
+      // }
 
-          return errorMsg
-        case 500:
-          return MESSAGE.UNKNOWN_ERROR
-        default:
-          return MESSAGE.UNKNOWN_ERROR
-      }
+      return errorResponse.userMessage
     }
-
     return null
   } catch (e) {
     console.error(e)

--- a/webapp/types/error.ts
+++ b/webapp/types/error.ts
@@ -2,9 +2,15 @@ export type FetchError = string
 
 // APIのエラー時のレスポンスの型
 export type ApiError = {
-  msg: string
+  code: number
+  developerMessage: string
+  userMessage: string
 }
 
 export const isApiError = (arg: any): arg is ApiError => {
-  return arg.msg !== undefined
+  return (
+    arg.code !== undefined &&
+    arg.developerMessage !== undefined &&
+    arg.userMessage !== undefined
+  )
 }


### PR DESCRIPTION
## 変更点
- メールアドレス認証コード送信ページを作成
- 各画面にナビゲーションを追加
- APIのエラー型を修正