### PR TITLE
JWTトークンを HTTP Only Cookie から取得するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ mkcert -install
 ```
 
 ```console
-cd reverse-proxy-for-dev && mkcert localhost
+cd reverse-proxy-for-dev && \
+mkcert -cert-file ./localhost.pem -key-file ./localhost-key.pem localhost "host.docker.internal"
 ```
 
 ### 各コンテナを起動

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -136,6 +136,10 @@ resource "aws_ecs_task_definition" "restapi" {
         name  = "AWS_SECRET_ACCESS_KEY"
         value = var.cognito_admin_secret_key
       },
+      {
+        name  = "ALLOWED_HOST"
+        value = var.allowed_domain
+      },
     ],
     logConfiguration = {
       logDriver = "awslogs", # CloudWatch Logsを使用する

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -137,7 +137,7 @@ resource "aws_ecs_task_definition" "restapi" {
         value = var.cognito_admin_secret_key
       },
       {
-        name  = "ALLOWED_HOST"
+        name  = "ALLOWED_DOMAIN"
         value = var.allowed_domain
       },
     ],

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -79,3 +79,9 @@ variable "db_port" {
   type        = number
   default     = 5432
 }
+
+variable "allowed_domain" {
+  description = "The domain name for the allowed domain"
+  type        = string
+  default     = "tune-trail.com"
+}

--- a/restapi/config/config.go
+++ b/restapi/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	CognitoUserPoolId   string `env:"COGNITO_USER_POOL_ID" envDefault:""`
 	CognitoClientId     string `env:"COGNITO_CLIENT_ID" envDefault:""`
 	CognitoClientSecret string `env:"COGNITO_CLIENT_SECRET" envDefault:""`
+	AllowedDomain       string `env:"ALLOWED_DOMAIN" envDefault:"localhost:3000"`
 }
 
 // Newは環境変数から設定を取得してConfigを返す

--- a/restapi/handler/auth_handler.go
+++ b/restapi/handler/auth_handler.go
@@ -18,7 +18,8 @@ type AuthService interface {
 }
 
 type AuthHandler struct {
-	Service AuthService
+	Service       AuthService
+	AllowedDomain string
 }
 
 // POST /auth/register
@@ -128,7 +129,30 @@ func (ah *AuthHandler) SignIn(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, tokens)
+	c.SetCookie(
+		"accessToken",
+		tokens.Access,
+		60*60*24*7, // TODO: 有効期限を短くする
+		"/",
+		"."+ah.AllowedDomain,
+		true, // Secure
+		true, // HttpOnly
+	)
+
+	c.SetCookie(
+		"refreshToken",
+		tokens.Refresh,
+		60*60*24*7, // TODO: 有効期限を考える
+		"/refresh",
+		"."+ah.AllowedDomain,
+		true, // Secure
+		true, // HttpOnly
+	)
+
+	// c.JSON(http.StatusOK, tokens)
+
+	// userIdを返したほうがいいかも
+	c.Status(http.StatusOK)
 }
 
 // POST /auth/refresh

--- a/restapi/handler/auth_handler_test.go
+++ b/restapi/handler/auth_handler_test.go
@@ -32,7 +32,8 @@ func (s *AuthHandlerTestSuite) SetupTest() {
 
 	asm := setupAuthServiceMock(s.T())
 	s.ah = &AuthHandler{
-		Service: asm,
+		Service:       asm,
+		AllowedDomain: "example.com",
 	}
 }
 
@@ -168,13 +169,13 @@ func (s *AuthHandlerTestSuite) TestSignIn() {
 			"success with username",
 			"testdata/auth/signin/ok_username_request.json.golden",
 			http.StatusOK,
-			"testdata/auth/signin/ok_username_response.json.golden",
+			"",
 		},
 		{
 			"success with email",
 			"testdata/auth/signin/ok_email_request.json.golden",
 			http.StatusOK,
-			"testdata/auth/signin/ok_email_response.json.golden",
+			"",
 		},
 		// フィールドの値が不正な場合
 		{
@@ -207,9 +208,14 @@ func (s *AuthHandlerTestSuite) TestSignIn() {
 
 			assert.Equal(s.T(), tt.wantStatus, resp.StatusCode)
 
+			// 正常系の場合
 			if tt.wantRespFile == "" {
+				// レスポンスのヘッダーにCookieが含まれていることを確認
+				cookie := resp.Header["Set-Cookie"]
+				assert.NotEmpty(s.T(), cookie)
 				return
 			}
+
 			wantResp := testutil.LoadFile(s.T(), tt.wantRespFile)
 			testutil.AssertResponseBody(s.T(), resp, wantResp)
 		})

--- a/restapi/handler/testdata/auth/signin/ok_email_response.json.golden
+++ b/restapi/handler/testdata/auth/signin/ok_email_response.json.golden
@@ -1,5 +1,0 @@
-{
-    "id": "dummy",
-    "access": "dummy",
-    "refresh": "dummy"
-}

--- a/restapi/handler/testdata/auth/signin/ok_username_response.json.golden
+++ b/restapi/handler/testdata/auth/signin/ok_username_response.json.golden
@@ -1,5 +1,0 @@
-{
-    "id": "dummy",
-    "access": "dummy",
-    "refresh": "dummy"
-}

--- a/restapi/router/router.go
+++ b/restapi/router/router.go
@@ -42,11 +42,12 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 			Repo: r,
 			Auth: a,
 		},
+		AllowedDomain: cfg.AllowedDomain,
 	}
 
 	router := gin.Default()
 
-	router.Use(handler.CorsMiddleware())
+	router.Use(handler.CorsMiddleware(cfg.AllowedDomain))
 
 	router.GET("/health", hh.HealthCheck)
 

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -38,6 +38,10 @@ WORKDIR /workspace/webapp
 
 COPY ./ ./
 
+# 証明書をインストール
+COPY ../reverse-proxy-for-dev/localhost.pem /usr/local/share/ca-certificates/localhost.crt
+RUN update-ca-certificates
+
 # 開発用のツールをインストール
 RUN apt-get update && apt-get install -y \
     jq \
@@ -45,6 +49,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g npm@latest && npm install create-next-app
+RUN npm install -g npm@latest
 
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## 変更点

- 許可するドメインを示す環境変数 `ALLOWED_DOMAIN` を追加
- 認証ミドルウェアが Cookie から値を取得するように変更
- `/auth/signin` エンドポイントがCookieの値をセットするように変更
- `Next.js`がローカル環境で証明書の検証をスキップするように変更