### PR TITLE
`/auth/signin`エンドポイントがユーザー情報を返すように変更

### DIFF
--- a/restapi/auth/jwt.go
+++ b/restapi/auth/jwt.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/kngnkg/tunetrail/restapi/clock"
+	"github.com/kngnkg/tunetrail/restapi/model"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jwt"
 )
@@ -74,4 +75,21 @@ func (j *JWTer) Verify(ctx context.Context, tokenString string) error {
 	}
 
 	return nil
+}
+
+func (j *JWTer) ParseIdToken(ctx context.Context, tokenString string) (*model.AuthInfo, error) {
+	token, err := jwt.Parse([]byte(tokenString))
+	if err != nil {
+		return nil, err
+	}
+
+	authInfo := &model.AuthInfo{}
+
+	id, _ := token.Get("cognito:username")
+	authInfo.Id = model.UserID(id.(string))
+
+	email, _ := token.Get("email")
+	authInfo.Email = email.(string)
+
+	return authInfo, nil
 }

--- a/restapi/handler/auth_handler.go
+++ b/restapi/handler/auth_handler.go
@@ -143,7 +143,7 @@ func (ah *AuthHandler) SignIn(c *gin.Context) {
 		"refreshToken",
 		tokens.Refresh,
 		60*60*24*7, // TODO: 有効期限を考える
-		"/refresh",
+		"/auth/refresh",
 		"."+ah.AllowedDomain,
 		true, // Secure
 		true, // HttpOnly

--- a/restapi/handler/auth_handler.go
+++ b/restapi/handler/auth_handler.go
@@ -14,6 +14,7 @@ type AuthService interface {
 	RegisterUser(ctx context.Context, data *model.UserRegistrationData) (*model.User, error)
 	ConfirmEmail(ctx context.Context, userName, code string) error
 	SignIn(ctx context.Context, data *model.UserSignInData) (*model.Tokens, error)
+	GetSignedInUser(ctx context.Context, idToken string) (*model.User, error)
 	RefreshToken(ctx context.Context, userIdentifier, refreshToken string) (string, error)
 }
 
@@ -129,6 +130,8 @@ func (ah *AuthHandler) SignIn(c *gin.Context) {
 		return
 	}
 
+	// HttpOnly で Secure なクッキーを設定する
+
 	c.SetCookie(
 		"accessToken",
 		tokens.Access,
@@ -149,10 +152,15 @@ func (ah *AuthHandler) SignIn(c *gin.Context) {
 		true, // HttpOnly
 	)
 
-	// c.JSON(http.StatusOK, tokens)
+	// サインインしたユーザーの情報を取得する
+	user, err := ah.Service.GetSignedInUser(c.Request.Context(), tokens.Id)
+	if err != nil {
+		c.Error(err)
+		errorResponse(c, http.StatusInternalServerError, ServerErrorCode)
+		return
+	}
 
-	// userIdを返したほうがいいかも
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusOK, user)
 }
 
 // POST /auth/refresh

--- a/restapi/handler/auth_handler_test.go
+++ b/restapi/handler/auth_handler_test.go
@@ -169,13 +169,13 @@ func (s *AuthHandlerTestSuite) TestSignIn() {
 			"success with username",
 			"testdata/auth/signin/ok_username_request.json.golden",
 			http.StatusOK,
-			"",
+			"testdata/auth/signin/ok_username_response.json.golden",
 		},
 		{
 			"success with email",
 			"testdata/auth/signin/ok_email_request.json.golden",
 			http.StatusOK,
-			"",
+			"testdata/auth/signin/ok_email_response.json.golden",
 		},
 		// フィールドの値が不正な場合
 		{
@@ -208,16 +208,15 @@ func (s *AuthHandlerTestSuite) TestSignIn() {
 
 			assert.Equal(s.T(), tt.wantStatus, resp.StatusCode)
 
-			// 正常系の場合
+			wantResp := testutil.LoadFile(s.T(), tt.wantRespFile)
+			testutil.AssertResponseBody(s.T(), resp, wantResp)
+
+			// 正常系の場合はレスポンスヘッダーにCookieが含まれていることを確認
 			if tt.wantRespFile == "" {
-				// レスポンスのヘッダーにCookieが含まれていることを確認
 				cookie := resp.Header["Set-Cookie"]
 				assert.NotEmpty(s.T(), cookie)
 				return
 			}
-
-			wantResp := testutil.LoadFile(s.T(), tt.wantRespFile)
-			testutil.AssertResponseBody(s.T(), resp, wantResp)
 		})
 	}
 }
@@ -274,6 +273,18 @@ func setupAuthServiceMock(t *testing.T) *AuthServiceMock {
 				Refresh: "dummy",
 			}
 			return tokens, nil
+		},
+		GetSignedInUserFunc: func(ctx context.Context, idToken string) (*model.User, error) {
+			u := &model.User{
+				Id:        "1",
+				UserName:  "dummy",
+				Name:      "dummy",
+				IconUrl:   "https://example.com/icon.png",
+				Bio:       "dummy",
+				CreatedAt: fc.Now(),
+				UpdatedAt: fc.Now(),
+			}
+			return u, nil
 		},
 	}
 

--- a/restapi/handler/middleware.go
+++ b/restapi/handler/middleware.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"log"
 	"net/http"
 	"time"
 
@@ -28,14 +27,13 @@ func CorsMiddleware(allowedDomain string) gin.HandlerFunc {
 			"Content-Length",
 			"Accept-Encoding",
 			"X-CSRF-Token",
-			"Authorization", // 不要になるかも
 		},
 		// 許可したいアクセス元の一覧
 		AllowOrigins: []string{
-			"https://" + allowedDomain,
-			"https://www." + allowedDomain,
-			"https://api." + allowedDomain,
+			"https://" + allowedDomain + ":3000",
+			"https://www." + allowedDomain + ":3000",
 		},
+		AllowCredentials: true,
 		// preflight requestで許可した後の接続可能時間
 		MaxAge: 24 * time.Hour,
 	})
@@ -51,8 +49,6 @@ func AuthMiddleware(j *auth.JWTer) gin.HandlerFunc {
 			errorResponse(c, http.StatusUnauthorized, NotAuthorizedCode)
 			return
 		}
-
-		log.Println("token: ", token)
 
 		// JWTの検証
 		if err := j.Verify(c, token); err != nil {

--- a/restapi/handler/moq_test.go
+++ b/restapi/handler/moq_test.go
@@ -260,6 +260,9 @@ var _ AuthService = &AuthServiceMock{}
 //			ConfirmEmailFunc: func(ctx context.Context, userName string, code string) error {
 //				panic("mock out the ConfirmEmail method")
 //			},
+//			GetSignedInUserFunc: func(ctx context.Context, idToken string) (*model.User, error) {
+//				panic("mock out the GetSignedInUser method")
+//			},
 //			RefreshTokenFunc: func(ctx context.Context, userIdentifier string, refreshToken string) (string, error) {
 //				panic("mock out the RefreshToken method")
 //			},
@@ -278,6 +281,9 @@ var _ AuthService = &AuthServiceMock{}
 type AuthServiceMock struct {
 	// ConfirmEmailFunc mocks the ConfirmEmail method.
 	ConfirmEmailFunc func(ctx context.Context, userName string, code string) error
+
+	// GetSignedInUserFunc mocks the GetSignedInUser method.
+	GetSignedInUserFunc func(ctx context.Context, idToken string) (*model.User, error)
 
 	// RefreshTokenFunc mocks the RefreshToken method.
 	RefreshTokenFunc func(ctx context.Context, userIdentifier string, refreshToken string) (string, error)
@@ -298,6 +304,13 @@ type AuthServiceMock struct {
 			UserName string
 			// Code is the code argument value.
 			Code string
+		}
+		// GetSignedInUser holds details about calls to the GetSignedInUser method.
+		GetSignedInUser []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// IdToken is the idToken argument value.
+			IdToken string
 		}
 		// RefreshToken holds details about calls to the RefreshToken method.
 		RefreshToken []struct {
@@ -323,10 +336,11 @@ type AuthServiceMock struct {
 			Data *model.UserSignInData
 		}
 	}
-	lockConfirmEmail sync.RWMutex
-	lockRefreshToken sync.RWMutex
-	lockRegisterUser sync.RWMutex
-	lockSignIn       sync.RWMutex
+	lockConfirmEmail    sync.RWMutex
+	lockGetSignedInUser sync.RWMutex
+	lockRefreshToken    sync.RWMutex
+	lockRegisterUser    sync.RWMutex
+	lockSignIn          sync.RWMutex
 }
 
 // ConfirmEmail calls ConfirmEmailFunc.
@@ -366,6 +380,42 @@ func (mock *AuthServiceMock) ConfirmEmailCalls() []struct {
 	mock.lockConfirmEmail.RLock()
 	calls = mock.calls.ConfirmEmail
 	mock.lockConfirmEmail.RUnlock()
+	return calls
+}
+
+// GetSignedInUser calls GetSignedInUserFunc.
+func (mock *AuthServiceMock) GetSignedInUser(ctx context.Context, idToken string) (*model.User, error) {
+	if mock.GetSignedInUserFunc == nil {
+		panic("AuthServiceMock.GetSignedInUserFunc: method is nil but AuthService.GetSignedInUser was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		IdToken string
+	}{
+		Ctx:     ctx,
+		IdToken: idToken,
+	}
+	mock.lockGetSignedInUser.Lock()
+	mock.calls.GetSignedInUser = append(mock.calls.GetSignedInUser, callInfo)
+	mock.lockGetSignedInUser.Unlock()
+	return mock.GetSignedInUserFunc(ctx, idToken)
+}
+
+// GetSignedInUserCalls gets all the calls that were made to GetSignedInUser.
+// Check the length with:
+//
+//	len(mockedAuthService.GetSignedInUserCalls())
+func (mock *AuthServiceMock) GetSignedInUserCalls() []struct {
+	Ctx     context.Context
+	IdToken string
+} {
+	var calls []struct {
+		Ctx     context.Context
+		IdToken string
+	}
+	mock.lockGetSignedInUser.RLock()
+	calls = mock.calls.GetSignedInUser
+	mock.lockGetSignedInUser.RUnlock()
 	return calls
 }
 

--- a/restapi/handler/testdata/auth/signin/ok_email_response.json.golden
+++ b/restapi/handler/testdata/auth/signin/ok_email_response.json.golden
@@ -1,0 +1,11 @@
+{
+    "id": "1",
+    "userName": "dummy",
+    "name": "dummy",
+    "iconUrl": "https://example.com/icon.png",
+    "bio": "dummy",
+    "password": "",
+    "email": "",
+    "createdAt": "2022-05-10T12:34:56Z",
+    "updatedAt": "2022-05-10T12:34:56Z"
+}

--- a/restapi/handler/testdata/auth/signin/ok_username_response.json.golden
+++ b/restapi/handler/testdata/auth/signin/ok_username_response.json.golden
@@ -1,0 +1,11 @@
+{
+    "id": "1",
+    "userName": "dummy",
+    "name": "dummy",
+    "iconUrl": "https://example.com/icon.png",
+    "bio": "dummy",
+    "password": "",
+    "email": "",
+    "createdAt": "2022-05-10T12:34:56Z",
+    "updatedAt": "2022-05-10T12:34:56Z"
+}

--- a/restapi/model/user.go
+++ b/restapi/model/user.go
@@ -25,6 +25,11 @@ type User struct {
 	UpdatedAt time.Time `json:"updatedAt" db:"updated_at"`
 }
 
+type AuthInfo struct {
+	Id    UserID `json:"id" binding:"required,uuid4"`
+	Email string `json:"email" binding:"email"`
+}
+
 type UserRegistrationData struct {
 	UserName string `json:"userName" binding:"required,min=3,max=20"`
 	Name     string `json:"name" binding:"required,min=3,max=20"`

--- a/restapi/router/router.go
+++ b/restapi/router/router.go
@@ -38,9 +38,10 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 	}
 	ah := &handler.AuthHandler{
 		Service: &service.AuthService{
-			DB:   db,
-			Repo: r,
-			Auth: a,
+			DB:    db,
+			Repo:  r,
+			Auth:  a,
+			JWTer: j,
 		},
 		AllowedDomain: cfg.AllowedDomain,
 	}

--- a/restapi/service/auth.go
+++ b/restapi/service/auth.go
@@ -12,9 +12,10 @@ import (
 )
 
 type AuthService struct {
-	DB   store.DBConnection
-	Repo UserRepository
-	Auth Auth
+	DB    store.DBConnection
+	Repo  UserRepository
+	Auth  Auth
+	JWTer JWTer
 }
 
 // RegisterUserはユーザーを登録する
@@ -136,6 +137,16 @@ func (as *AuthService) SignIn(ctx context.Context, data *model.UserSignInData) (
 		return nil, err
 	}
 	return tokens, nil
+}
+
+func (as *AuthService) GetSignedInUser(ctx context.Context, idToken string) (*model.User, error) {
+	parsed, err := as.JWTer.ParseIdToken(ctx, idToken)
+	if err != nil {
+		// TODO: エラー処理
+		return nil, err
+	}
+
+	return as.Repo.GetUserByUserId(ctx, as.DB, parsed.Id)
 }
 
 func (as *AuthService) RefreshToken(ctx context.Context, userId, refreshToken string) (string, error) {

--- a/restapi/service/interfaces.go
+++ b/restapi/service/interfaces.go
@@ -15,6 +15,10 @@ type Auth interface {
 	RefreshToken(ctx context.Context, userIdentifier, refreshToken string) (*model.Tokens, error)
 }
 
+type JWTer interface {
+	ParseIdToken(ctx context.Context, idToken string) (*model.AuthInfo, error)
+}
+
 type UserRepository interface {
 	// WithTransactionはトランザクションを実行する
 	WithTransaction(ctx context.Context, db store.Beginner, f func(tx *sqlx.Tx) error) error
@@ -22,8 +26,9 @@ type UserRepository interface {
 	UserExistsByUserName(ctx context.Context, db store.Queryer, userName string) (bool, error)
 	// GetUserByUserNameはユーザー名からユーザーを取得する
 	GetUserByUserName(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
+	// GetUserByUserIdはユーザーIDからユーザーを取得する
+	GetUserByUserId(ctx context.Context, db store.Queryer, id model.UserID) (*model.User, error)
 	// RegisterUserはユーザーを登録する
-	// RegisterUserInfo
 	RegisterUser(ctx context.Context, db store.Execer, u *model.User) error
 	// UpdateUserはユーザーを更新する
 	UpdateUser(ctx context.Context, db store.Execer, u *model.User) error

--- a/restapi/service/moq_test.go
+++ b/restapi/service/moq_test.go
@@ -96,6 +96,9 @@ var _ UserRepository = &UserRepositoryMock{}
 //			DeleteUserByUserNameFunc: func(ctx context.Context, db store.Execer, userName string) error {
 //				panic("mock out the DeleteUserByUserName method")
 //			},
+//			GetUserByUserIdFunc: func(ctx context.Context, db store.Queryer, id model.UserID) (*model.User, error) {
+//				panic("mock out the GetUserByUserId method")
+//			},
 //			GetUserByUserNameFunc: func(ctx context.Context, db store.Queryer, userName string) (*model.User, error) {
 //				panic("mock out the GetUserByUserName method")
 //			},
@@ -120,6 +123,9 @@ var _ UserRepository = &UserRepositoryMock{}
 type UserRepositoryMock struct {
 	// DeleteUserByUserNameFunc mocks the DeleteUserByUserName method.
 	DeleteUserByUserNameFunc func(ctx context.Context, db store.Execer, userName string) error
+
+	// GetUserByUserIdFunc mocks the GetUserByUserId method.
+	GetUserByUserIdFunc func(ctx context.Context, db store.Queryer, id model.UserID) (*model.User, error)
 
 	// GetUserByUserNameFunc mocks the GetUserByUserName method.
 	GetUserByUserNameFunc func(ctx context.Context, db store.Queryer, userName string) (*model.User, error)
@@ -146,6 +152,15 @@ type UserRepositoryMock struct {
 			Db store.Execer
 			// UserName is the userName argument value.
 			UserName string
+		}
+		// GetUserByUserId holds details about calls to the GetUserByUserId method.
+		GetUserByUserId []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Db is the db argument value.
+			Db store.Queryer
+			// ID is the id argument value.
+			ID model.UserID
 		}
 		// GetUserByUserName holds details about calls to the GetUserByUserName method.
 		GetUserByUserName []struct {
@@ -194,6 +209,7 @@ type UserRepositoryMock struct {
 		}
 	}
 	lockDeleteUserByUserName sync.RWMutex
+	lockGetUserByUserId      sync.RWMutex
 	lockGetUserByUserName    sync.RWMutex
 	lockRegisterUser         sync.RWMutex
 	lockUpdateUser           sync.RWMutex
@@ -238,6 +254,46 @@ func (mock *UserRepositoryMock) DeleteUserByUserNameCalls() []struct {
 	mock.lockDeleteUserByUserName.RLock()
 	calls = mock.calls.DeleteUserByUserName
 	mock.lockDeleteUserByUserName.RUnlock()
+	return calls
+}
+
+// GetUserByUserId calls GetUserByUserIdFunc.
+func (mock *UserRepositoryMock) GetUserByUserId(ctx context.Context, db store.Queryer, id model.UserID) (*model.User, error) {
+	if mock.GetUserByUserIdFunc == nil {
+		panic("UserRepositoryMock.GetUserByUserIdFunc: method is nil but UserRepository.GetUserByUserId was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Db  store.Queryer
+		ID  model.UserID
+	}{
+		Ctx: ctx,
+		Db:  db,
+		ID:  id,
+	}
+	mock.lockGetUserByUserId.Lock()
+	mock.calls.GetUserByUserId = append(mock.calls.GetUserByUserId, callInfo)
+	mock.lockGetUserByUserId.Unlock()
+	return mock.GetUserByUserIdFunc(ctx, db, id)
+}
+
+// GetUserByUserIdCalls gets all the calls that were made to GetUserByUserId.
+// Check the length with:
+//
+//	len(mockedUserRepository.GetUserByUserIdCalls())
+func (mock *UserRepositoryMock) GetUserByUserIdCalls() []struct {
+	Ctx context.Context
+	Db  store.Queryer
+	ID  model.UserID
+} {
+	var calls []struct {
+		Ctx context.Context
+		Db  store.Queryer
+		ID  model.UserID
+	}
+	mock.lockGetUserByUserId.RLock()
+	calls = mock.calls.GetUserByUserId
+	mock.lockGetUserByUserId.RUnlock()
 	return calls
 }
 

--- a/restapi/store/user.go
+++ b/restapi/store/user.go
@@ -15,6 +15,26 @@ const (
 	ConstraintUserName = "users_user_name_key"
 )
 
+// GetUserByUserId はユーザーIDからユーザーを取得する
+func (r *Repository) GetUserByUserId(ctx context.Context, db Queryer, id model.UserID) (*model.User, error) {
+	u := &model.User{}
+	query := `SELECT id, user_name, name, icon_url, bio, created_at, updated_at
+			FROM users
+			WHERE id = $1;`
+
+	if err := db.GetContext(ctx, u, query, string(id)); err != nil {
+		// ユーザーが存在しない場合はエラーをラップして返す
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("%w: %w", ErrUserNotFound, err)
+		}
+		return nil, err
+	}
+	// UTCに変換
+	u.CreatedAt = u.CreatedAt.UTC()
+	u.UpdatedAt = u.UpdatedAt.UTC()
+	return u, nil
+}
+
 // GetUserByUserName はユーザー名からユーザーを取得する
 func (r *Repository) GetUserByUserName(ctx context.Context, db Queryer, userName string) (*model.User, error) {
 	u := &model.User{}


### PR DESCRIPTION
## 変更点

- IDトークンをパースする関数を追加
- serviceにIDトークンからユーザー情報を取得する関数を追加
- storeにユーザーIDからユーザーを取得する関数を追加