### PR TITLE
トークンのリフレッシュを`Next.js`の`API Routes`を経由するように変更

### DIFF
--- a/restapi/config/config.go
+++ b/restapi/config/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	CognitoUserPoolId   string `env:"COGNITO_USER_POOL_ID" envDefault:""`
 	CognitoClientId     string `env:"COGNITO_CLIENT_ID" envDefault:""`
 	CognitoClientSecret string `env:"COGNITO_CLIENT_SECRET" envDefault:""`
-	AllowedDomain       string `env:"ALLOWED_DOMAIN" envDefault:"localhost:3000"`
+	AllowedDomain       string `env:"ALLOWED_DOMAIN" envDefault:"localhost"`
 }
 
 // Newは環境変数から設定を取得してConfigを返す

--- a/restapi/handler/moq_test.go
+++ b/restapi/handler/moq_test.go
@@ -263,7 +263,7 @@ var _ AuthService = &AuthServiceMock{}
 //			GetSignedInUserFunc: func(ctx context.Context, idToken string) (*model.User, error) {
 //				panic("mock out the GetSignedInUser method")
 //			},
-//			RefreshTokenFunc: func(ctx context.Context, userIdentifier string, refreshToken string) (string, error) {
+//			RefreshTokenFunc: func(ctx context.Context, idToken string, refreshToken string) (*model.Tokens, error) {
 //				panic("mock out the RefreshToken method")
 //			},
 //			RegisterUserFunc: func(ctx context.Context, data *model.UserRegistrationData) (*model.User, error) {
@@ -286,7 +286,7 @@ type AuthServiceMock struct {
 	GetSignedInUserFunc func(ctx context.Context, idToken string) (*model.User, error)
 
 	// RefreshTokenFunc mocks the RefreshToken method.
-	RefreshTokenFunc func(ctx context.Context, userIdentifier string, refreshToken string) (string, error)
+	RefreshTokenFunc func(ctx context.Context, idToken string, refreshToken string) (*model.Tokens, error)
 
 	// RegisterUserFunc mocks the RegisterUser method.
 	RegisterUserFunc func(ctx context.Context, data *model.UserRegistrationData) (*model.User, error)
@@ -316,8 +316,8 @@ type AuthServiceMock struct {
 		RefreshToken []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// UserIdentifier is the userIdentifier argument value.
-			UserIdentifier string
+			// IdToken is the idToken argument value.
+			IdToken string
 			// RefreshToken is the refreshToken argument value.
 			RefreshToken string
 		}
@@ -420,23 +420,23 @@ func (mock *AuthServiceMock) GetSignedInUserCalls() []struct {
 }
 
 // RefreshToken calls RefreshTokenFunc.
-func (mock *AuthServiceMock) RefreshToken(ctx context.Context, userIdentifier string, refreshToken string) (string, error) {
+func (mock *AuthServiceMock) RefreshToken(ctx context.Context, idToken string, refreshToken string) (*model.Tokens, error) {
 	if mock.RefreshTokenFunc == nil {
 		panic("AuthServiceMock.RefreshTokenFunc: method is nil but AuthService.RefreshToken was just called")
 	}
 	callInfo := struct {
-		Ctx            context.Context
-		UserIdentifier string
-		RefreshToken   string
+		Ctx          context.Context
+		IdToken      string
+		RefreshToken string
 	}{
-		Ctx:            ctx,
-		UserIdentifier: userIdentifier,
-		RefreshToken:   refreshToken,
+		Ctx:          ctx,
+		IdToken:      idToken,
+		RefreshToken: refreshToken,
 	}
 	mock.lockRefreshToken.Lock()
 	mock.calls.RefreshToken = append(mock.calls.RefreshToken, callInfo)
 	mock.lockRefreshToken.Unlock()
-	return mock.RefreshTokenFunc(ctx, userIdentifier, refreshToken)
+	return mock.RefreshTokenFunc(ctx, idToken, refreshToken)
 }
 
 // RefreshTokenCalls gets all the calls that were made to RefreshToken.
@@ -444,14 +444,14 @@ func (mock *AuthServiceMock) RefreshToken(ctx context.Context, userIdentifier st
 //
 //	len(mockedAuthService.RefreshTokenCalls())
 func (mock *AuthServiceMock) RefreshTokenCalls() []struct {
-	Ctx            context.Context
-	UserIdentifier string
-	RefreshToken   string
+	Ctx          context.Context
+	IdToken      string
+	RefreshToken string
 } {
 	var calls []struct {
-		Ctx            context.Context
-		UserIdentifier string
-		RefreshToken   string
+		Ctx          context.Context
+		IdToken      string
+		RefreshToken string
 	}
 	mock.lockRefreshToken.RLock()
 	calls = mock.calls.RefreshToken

--- a/webapp/app/api/refresh/route.ts
+++ b/webapp/app/api/refresh/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { env } from "@/env.mjs"
+import fetcher from "@/lib/fetcher"
+
+type RefreshToken = {
+  IdToken: string
+  RefreshToken: string
+}
+
+export async function POST(req: NextRequest) {
+  const idCookie = req.cookies.get("idToken")
+
+  if (!idCookie) {
+    console.log("idToken is not found")
+    return new Response("Unauthorized", { status: 403 })
+  }
+
+  const refreshCookie = req.cookies.get("refreshToken")
+
+  if (!refreshCookie) {
+    console.log("refreshToken is not found")
+    return new Response("Unauthorized", { status: 403 })
+  }
+
+  const body: RefreshToken = {
+    IdToken: idCookie.value,
+    RefreshToken: refreshCookie.value,
+  }
+
+  const apiResp = await fetcher(`${env.API_ROOT}/auth/refresh`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  })
+
+  let resp = new NextResponse()
+
+  resp.cookies.set("idToken", apiResp.idToken, {
+    httpOnly: true,
+    maxAge: 60 * 60 * 24 * 7, // 考える
+    path: "/",
+    domain: `.${env.ALLOWED_DOMAIN}`,
+    sameSite: "none",
+    secure: true,
+  })
+
+  resp.cookies.set("accessToken", apiResp.accessToken, {
+    httpOnly: true,
+    maxAge: 60 * 60 * 24 * 7, // 考える
+    path: "/",
+    domain: `.${env.ALLOWED_DOMAIN}`,
+    sameSite: "none",
+    secure: true,
+  })
+
+  return resp
+}

--- a/webapp/env.mjs
+++ b/webapp/env.mjs
@@ -2,18 +2,22 @@ import { createEnv } from "@t3-oss/env-nextjs"
 import { z } from "zod"
 
 export const env = createEnv({
-  //   server: {
-  //     COGNITO_CLIENT_ID: z.string(),
-  //     COGNITO_CLIENT_SECRET: z.string(),
-  //     COGNITO_ISSUER: z.string().url(),
-  //   },
+  server: {
+    TUNETRAIL_AWS_REGION: z.string(),
+    COGNITO_USER_POOL_ID: z.string(),
+    ALLOWED_DOMAIN: z.string(),
+    API_ROOT: z.string().url(),
+  },
   client: {
     NEXT_PUBLIC_API_ROOT: z.string().url(),
+    NEXT_PUBLIC_AUTH_API_ROOT: z.string().url(),
   },
   runtimeEnv: {
     NEXT_PUBLIC_API_ROOT: process.env.NEXT_PUBLIC_API_ROOT,
-    // COGNITO_CLIENT_ID: process.env.COGNITO_CLIENT_ID,
-    // COGNITO_CLIENT_SECRET: process.env.COGNITO_CLIENT_SECRET,
-    // COGNITO_ISSUER: process.env.COGNITO_ISSUER,
+    NEXT_PUBLIC_AUTH_API_ROOT: process.env.NEXT_PUBLIC_AUTH_API_ROOT,
+    TUNETRAIL_AWS_REGION: process.env.TUNETRAIL_AWS_REGION,
+    COGNITO_USER_POOL_ID: process.env.COGNITO_USER_POOL_ID,
+    ALLOWED_DOMAIN: process.env.ALLOWED_DOMAIN,
+    API_ROOT: process.env.API_ROOT,
   },
 })

--- a/webapp/lib/fetcher.ts
+++ b/webapp/lib/fetcher.ts
@@ -1,4 +1,4 @@
-import { refreshAccessToken } from "@/services/auth/refreshAccessToken"
+import { refreshToken } from "@/services/auth/refreshToken"
 
 import { env } from "@/env.mjs"
 import { isApiError } from "@/types/error"
@@ -26,7 +26,7 @@ export const fetcher = async (
         switch (errResp.code) {
           case 4105:
             // トークンが期限切れの場合はリフレッシュトークンを送信して再度リクエストを送る
-            await refreshAccessToken(env.NEXT_PUBLIC_API_ROOT)
+            await refreshToken(env.NEXT_PUBLIC_AUTH_API_ROOT)
             return fetcher(resource, init)
           // case 4106:
           // リフレッシュトークンが期限切れの場合はログイン画面に遷移する

--- a/webapp/services/auth/refreshAccessToken.ts
+++ b/webapp/services/auth/refreshAccessToken.ts
@@ -1,8 +1,0 @@
-import fetcher from "@/lib/fetcher"
-
-export const refreshAccessToken = async (apiRoot: string): Promise<void> => {
-  return await fetcher(`${apiRoot}/auth/refresh`, {
-    method: "POST",
-    credentials: "include",
-  })
-}

--- a/webapp/services/auth/refreshToken.ts
+++ b/webapp/services/auth/refreshToken.ts
@@ -1,0 +1,8 @@
+import fetcher from "@/lib/fetcher"
+
+export const refreshToken = async (apiRoot: string): Promise<void> => {
+  return await fetcher(`${apiRoot}/refresh`, {
+    method: "POST",
+    credentials: "include",
+  })
+}

--- a/webapp/services/user/get-user.ts
+++ b/webapp/services/user/get-user.ts
@@ -1,0 +1,19 @@
+import { FetchError, isApiError } from "@/types/error"
+import { User, isUser } from "@/types/user"
+import fetcher from "@/lib/fetcher"
+
+export const getUser = async (
+  apiRoot: string,
+  userName: string
+): Promise<User | FetchError> => {
+  const data = await fetcher(`${apiRoot}/user/${userName}`, {
+    method: "GET",
+    credentials: "include",
+  })
+
+  if (!isUser(data)) {
+    throw new Error("Failed to fetch data from the API.")
+  }
+
+  return data
+}

--- a/webapp/setupEnv.js
+++ b/webapp/setupEnv.js
@@ -1,3 +1,8 @@
 module.exports = () => {
-  process.env.NEXT_PUBLIC_API_ROOT = "http://example.com/api"
+  process.env.NEXT_PUBLIC_API_ROOT = "http://api.example.com"
+  process.env.NEXT_PUBLIC_AUTH_API_ROOT = "http://example.com/api"
+  process.env.TUNETRAIL_AWS_REGION = "test-region"
+  process.env.COGNITO_USER_POOL_ID = "test-pool-id"
+  process.env.ALLOWED_DOMAIN = "example.com"
+  process.env.API_ROOT = "http://api.example.com"
 }


### PR DESCRIPTION
## 変更点

- `restapi`の`/auth/refresh`が`Set-Cookie`ではなくレスポンスボディでトークンを返すように変更
- `webapp`の`/api/refresh`で`Set-Cookie`するように変更
- その他リファクタリング