### PR TITLE
ユーザー削除を物理削除から論理削除に変更

### DIFF
--- a/migration/_tools/postgres/schema.sql
+++ b/migration/_tools/postgres/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE users (
     name VARCHAR(100),
     icon_url VARCHAR(100),
     bio VARCHAR(1000),
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );


### PR DESCRIPTION
## 変更点

- `users`テーブルに論理削除フラグ`is_deleted`を追加
- 参照系クエリが`is_deleted`を確認するように変更
- `store.DeleteUserByUserName`を`is_deleted`を`true`に変更するように変更