### PR TITLE
`/posts/:post_id/replies`ルートを追加

### DIFF
--- a/restapi/handler/utils.go
+++ b/restapi/handler/utils.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 	"github.com/kngnkg/tunetrail/restapi/model"
 )
@@ -11,4 +13,25 @@ func getSignedInUserId(c *gin.Context) model.UserID {
 
 func getUserIdFromPath(c *gin.Context) model.UserID {
 	return model.UserID(c.Param("user_id"))
+}
+
+func getPostIdFromPath(c *gin.Context) string {
+	return c.Param("post_id")
+}
+
+func getPagenationFromQuery(c *gin.Context) (*model.Pagenation, error) {
+	nc := c.DefaultQuery("next_cursor", "")
+	pc := c.DefaultQuery("previous_cursor", "")
+	lstr := c.DefaultQuery("limit", "10")
+
+	l, err := strconv.Atoi(lstr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.Pagenation{
+		NextCursor:     nc,
+		PreviousCursor: pc,
+		Limit:          l,
+	}, nil
 }

--- a/restapi/router/router.go
+++ b/restapi/router/router.go
@@ -91,6 +91,8 @@ func SetupRouter(cfg *config.Config) (*gin.Engine, func(), error) {
 		posts.Use(handler.AuthMiddleware(j))
 
 		posts.POST("", ph.AddPost)
+		// posts.GET("/:post_id", ph.GetPostById)
+		posts.GET("/:post_id/replies", ph.GetReplies)
 	}
 
 	return router, cleanup, nil

--- a/restapi/service/interfaces.go
+++ b/restapi/service/interfaces.go
@@ -40,6 +40,7 @@ type PostRepository interface {
 	GetPostById(ctx context.Context, db store.Queryer, postId string) (*model.Post, error)
 	GetFolloweesByUserId(ctx context.Context, db store.Queryer, signedInUserId model.UserID) ([]*model.User, error)
 	GetPostsByUserIdsNext(ctx context.Context, db store.Queryer, userId []model.UserID, pagenation *model.Pagenation) (*model.Timeline, error)
+	GetReplies(ctx context.Context, db store.Queryer, parentPostId string, pagenation *model.Pagenation) (*model.Timeline, error)
 }
 
 type HealthRepository interface {

--- a/restapi/service/post.go
+++ b/restapi/service/post.go
@@ -82,3 +82,13 @@ func (ps *PostService) GetPostsByUserId(ctx context.Context, userId model.UserID
 
 	return timeline, nil
 }
+
+func (ps *PostService) GetReplies(ctx context.Context, postId string, pagenation *model.Pagenation) (*model.Timeline, error) {
+	timeline, err := ps.Repo.GetReplies(ctx, ps.DB, postId, pagenation)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return timeline, nil
+}

--- a/restapi/store/post.go
+++ b/restapi/store/post.go
@@ -13,18 +13,21 @@ func (r *Repository) GetPostsByUserIdsNext(ctx context.Context, db Queryer, user
 	baseQuery := `
 		SELECT
 			p.id,
-			p.body,
-			p.created_at,
-			p.updated_at,
+			p.parent_id,
 			u.id AS "user.id",
 			u.user_name AS "user.user_name",
 			u.name AS "user.name",
 			u.icon_url AS "user.icon_url",
 			u.bio AS "user.bio",
-			u.created_at AS "user.created_at"
+			u.created_at AS "user.created_at",
+			u.updated_at AS "user.updated_at",
+			p.body,
+			p.created_at,
+			p.updated_at
 		FROM posts p
 		INNER JOIN users u ON p.user_id = u.id
-		WHERE user_id = ANY ($1) AND p.parent_id IS NULL
+		WHERE user_id = ANY ($1)
+		AND p.parent_id IS NULL;
 	`
 
 	limit := pagenation.Limit + 1 // 次のページがあるかどうかを判定するために1件多く取得する
@@ -55,44 +58,10 @@ func (r *Repository) GetPostsByUserIdsNext(ctx context.Context, db Queryer, user
 		return nil, err
 	}
 
-	if len(posts) == limit {
-		// 次のページがある場合は、次のページのためにカーソルをセットする
-		pagenation.NextCursor = posts[limit-1].Id
-		posts = posts[:limit-1]
-	} else {
-		pagenation.NextCursor = ""
-	}
-
-	tl := &model.Timeline{
-		Posts:      posts,
-		Pagenation: pagenation,
-	}
+	tl := handlePagenation(posts, pagenation)
 
 	return tl, nil
 }
-
-// func (r *Repository) GetPostsByUserIdsPrevious(ctx context.Context, db Queryer, userId []model.UserID, previousCursor string) ([]*model.Post, error) {
-// 	var posts []*model.Post
-
-// 	statement := `
-// 	SELECT id, user_id, body, created_at, updated_at
-// 	FROM posts
-// 	WHERE user_id = ANY ($1)
-// 	AND created_at <= (
-// 		SELECT created_at
-// 		FROM posts
-// 		WHERE id = $2)
-// 	ORDER BY created_at ASC
-// 	LIMIT 10;
-// 	`
-
-// 	err := db.SelectContext(ctx, &posts, statement, userId, previousCursor)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	return posts, nil
-// }
 
 func (r *Repository) GetPostById(ctx context.Context, db Queryer, postId string) (*model.Post, error) {
 	p := &model.Post{}
@@ -121,6 +90,88 @@ func (r *Repository) GetPostById(ctx context.Context, db Queryer, postId string)
 	}
 
 	return p, nil
+}
+
+// 昇順で取得する
+func (r *Repository) GetReplies(ctx context.Context, db Queryer, parentPostId string, pagenation *model.Pagenation) (*model.Timeline, error) {
+	var posts []*model.Post
+
+	baseQuery := `
+		WITH RECURSIVE post_tree AS (
+			-- ベースケース
+			SELECT
+				p.id,
+				p.parent_id,
+				p.body,
+				p.created_at,
+				p.updated_at,
+				u.id AS "user.id",
+				u.user_name AS "user.user_name",
+				u.name AS "user.name",
+				u.icon_url AS "user.icon_url",
+				u.bio AS "user.bio",
+				u.created_at AS "user.created_at",
+				u.updated_at AS "user.updated_at"
+			FROM posts p
+			JOIN users u ON p.user_id = u.id
+			WHERE p.id = $1 -- ルートの投稿を取得
+
+			UNION ALL
+
+			-- 再帰的ケース
+			SELECT
+				child.id,
+				child.parent_id,
+				child.body,
+				child.created_at,
+				child.updated_at,
+				u.id AS "user.id",
+				u.user_name AS "user.user_name",
+				u.name AS "user.name",
+				u.icon_url AS "user.icon_url",
+				u.bio AS "user.bio",
+				u.created_at AS "user.created_at",
+				u.updated_at AS "user.updated_at"
+			FROM posts child
+			JOIN post_tree pt ON child.parent_id = pt.id
+			JOIN users u ON child.user_id = u.id
+		)
+
+		SELECT * FROM post_tree
+		WHERE parent_id IS NOT NULL -- ルートの投稿を除く
+	`
+
+	limit := pagenation.Limit + 1 // 次のページがあるかどうかを判定するために1件多く取得する
+
+	queryArgs := []interface{}{parentPostId, limit}
+
+	var statement string
+
+	if pagenation.NextCursor == "" {
+		statement = baseQuery + `
+			ORDER BY created_at ASC
+			LIMIT $2;
+		`
+	} else {
+		statement = baseQuery + `
+			AND created_at <= (
+				SELECT created_at
+				FROM posts
+				WHERE id = $3)
+			ORDER BY p.created_at ASC
+			LIMIT $2;
+		`
+
+		queryArgs = append(queryArgs, pagenation.NextCursor)
+	}
+
+	if err := db.SelectContext(ctx, &posts, statement, queryArgs...); err != nil {
+		return nil, err
+	}
+
+	tl := handlePagenation(posts, pagenation)
+
+	return tl, nil
 }
 
 func (r *Repository) AddPost(ctx context.Context, db Queryer, p *model.Post) (string, error) {
@@ -155,4 +206,23 @@ func (r *Repository) AddPost(ctx context.Context, db Queryer, p *model.Post) (st
 	}
 
 	return id, nil
+}
+
+func handlePagenation(posts []*model.Post, pagenation *model.Pagenation) *model.Timeline {
+	limit := pagenation.Limit + 1 // 次のページがあるかどうかを判定するために1件多く取得する
+
+	if len(posts) == limit {
+		// 次のページがある場合は、次のページのためにカーソルをセットする
+		pagenation.NextCursor = posts[limit-1].Id
+		posts = posts[:limit-1]
+	} else {
+		pagenation.NextCursor = ""
+	}
+
+	tl := &model.Timeline{
+		Posts:      posts,
+		Pagenation: pagenation,
+	}
+
+	return tl
 }


### PR DESCRIPTION
## 変更点

- `/posts/:post_id/replies`ルートを追加
- ページネーション情報をクエリパラメータから取得する処理を関数化
- `model.Tilmeline`構造体にページネーションを設定する処理を関数化